### PR TITLE
Adjust queries for structure returned by `describe-image-scan-findings`

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -88,13 +88,17 @@ scan_status="IN_PROGRESS"
 i="0"
 while [ "${scan_status}" = "IN_PROGRESS" ]  && [ "$i" -le "100" ]
 do
+    echo "Poll attempt ${i}..."
     scan_status=$(aws ecr describe-image-scan-findings \
         --registry-id "${REPOSITORY_ID}" \
         --repository-name "${REPO_NAME}" \
         --image-id "${image_identifier}" \
         --query "imageScanStatus.status" \
         --output text)
-    sleep 3
+
+    # Give some time for the results to be available
+    [ "$i" != "0" ] && sleep 3
+
     ((i=i+1))
 done
 

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -70,6 +70,19 @@ IFS="." read -ra dot_fields <<< "${IMAGE_NAME}"
 REPOSITORY_ID="${dot_fields[0]}"
 REGION="${dot_fields[3]}"
 
+echo "--- retrieving image digest"
+
+image_digest=$(aws ecr describe-images \
+        --registry-id "${REPOSITORY_ID}" \
+        --repository-name "${REPO_NAME}" \
+        --image-id imageTag="${IMAGE_TAG}" \
+        --query "imageDetails[0].imageDigest" \
+        --output text)
+
+image_identifier="imageDigest=${image_digest}"
+
+echo "--- waiting for scan results to be available..."
+
 # poll until scan is COMPLETE or FAILED
 scan_status="IN_PROGRESS"
 i="0"
@@ -78,43 +91,44 @@ do
     scan_status=$(aws ecr describe-image-scan-findings \
         --registry-id "${REPOSITORY_ID}" \
         --repository-name "${REPO_NAME}" \
-        --image-ids imageTag="${IMAGE_TAG}" \
-        --query "imageDetails[0].imageScanStatus.status" \
+        --image-id "${image_identifier}" \
+        --query "imageScanStatus.status" \
         --output text)
     sleep 3
     ((i=i+1))
 done
 
+if [[ "${scan_status}" != "COMPLETE" && "${scan_status}" != "ACTIVE" ]]; then
+    annotation=$(printf "Error: ECR vulnerability scan failed with status: %s\n" "${scan_status}")
+
+    echo "^^^ +++"
+    echo "${annotation}"
+
+    buildkite-agent annotate --style error --context "exit_reason${IMAGE_LABEL_APP}" "${annotation}"
+
+    exit 1
+fi
+
+echo "scan complete"
+
+echo "--- querying results..."
+
 # retrieve counts of criticals and highs or fail build if scan failed
-case "${scan_status}" in
-    "COMPLETE")
-        criticals=$(aws ecr describe-image-scan-findings \
-            --registry-id "${REPOSITORY_ID}" \
-            --repository-name "${REPO_NAME}" \
-            --image-ids imageTag="${IMAGE_TAG}" \
-            --query "imageDetails[0].imageScanFindingsSummary.findingSeverityCounts.CRITICAL" \
-            --output text)
-        if [ "${criticals}" = "None" ]; then criticals="0"; fi
-        highs=$(aws ecr describe-image-scan-findings \
-            --registry-id "${REPOSITORY_ID}" \
-            --repository-name "${REPO_NAME}" \
-            --image-ids imageTag="${IMAGE_TAG}" \
-            --query "imageDetails[0].imageScanFindingsSummary.findingSeverityCounts.HIGH" \
-            --output text)
-        if [ "${highs}" = "None" ]; then highs="0"; fi
-        image_digest=$(aws ecr describe-image-scan-findings \
-            --registry-id "${REPOSITORY_ID}" \
-            --repository-name "${REPO_NAME}" \
-            --image-ids imageTag="${IMAGE_TAG}" \
-            --query "imageDetails[0].imageDigest" \
-            --output text)
-        ;;
-    *)
-        annotation=$(printf "Error: ECR vulnerability scan failed with status: %s\n" "${scan_status}")
-        buildkite-agent annotate --style error --context "exit_reason${IMAGE_LABEL_APP}" "${annotation}"
-        exit 1
-        ;;
-esac
+criticals=$(aws ecr describe-image-scan-findings \
+    --registry-id "${REPOSITORY_ID}" \
+    --repository-name "${REPO_NAME}" \
+    --image-id "${image_identifier}" \
+    --query "imageScanFindings.findingSeverityCounts.CRITICAL" \
+    --output text)
+if [ "${criticals}" = "None" ]; then criticals="0"; fi
+
+highs=$(aws ecr describe-image-scan-findings \
+    --registry-id "${REPOSITORY_ID}" \
+    --repository-name "${REPO_NAME}" \
+    --image-id "${image_identifier}" \
+    --query "imageScanFindings.findingSeverityCounts.HIGH" \
+    --output text)
+if [ "${highs}" = "None" ]; then highs="0"; fi
 
 # report results
 vuln_url=$(printf "https://%s.console.aws.amazon.com/ecr/repositories/private/%s/%s/image/%s/scan-results/?region=%s" "${REGION}" "${REPOSITORY_ID}" "${REPO_NAME}" "${image_digest}" "${REGION}")

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -1,6 +1,24 @@
 #! /bin/bash
 set -euo pipefail
 
+function notify_error {
+    exit_statement="
+A failure occurred while attempting to retrieve ECR scan results.
+
+This will not block CI, but please notify the ecr-scan-plugin maintainers of the issue.
+"
+
+    echo "^^^ +++"
+    echo "${exit_statement}"
+
+    # try to add an annotation, but skip if it doesn't work
+    buildkite-agent annotate --style warning "${exit_statement}" || true
+
+    exit 0
+}
+
+trap notify_error ERR
+
 # check all inputs exist and are valid
 image_name_pattern="^[0-9]{12}\.dkr\.ecr\.[a-z][a-z1-9-]+\.amazonaws.com/[^:]+:[^:]+$"
 count_pattern="^[0-9]+$"


### PR DESCRIPTION
Follows on from changes started in #2.

The `describe-image-scan-findings` has a different result structure, requiring changes. There is also an issue where querying findings by tag didn't seem to work, so we query the digest first and use that.

Lastly, the output includes more progress info, and traps any command error. The plugin will now annotate the build to announce that it has a problem, rather than blocking CI when there's an AWS communication/permissions issue.

The trap behaviour may be temporary as we work through a number of issues with the new ECR inspector.