### PR TITLE
Annotate build if image is unsupported instead of causing pipeline failure

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -99,6 +99,8 @@ image_digest=$(aws ecr describe-images \
 
 image_identifier="imageDigest=${image_digest}"
 
+echo "Using image digest: ${image_digest}"
+
 echo "--- waiting for scan results to be available..."
 
 # poll until scan is COMPLETE or FAILED

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -122,7 +122,17 @@ do
     ((i=i+1))
 done
 
-if [[ "${scan_status}" != "COMPLETE" && "${scan_status}" != "ACTIVE" ]]; then
+if [[ "${scan_status}" == "UNSUPPORTED_IMAGE" ]]; then
+    annotation=$(printf "Warning: ECR vulnerability scan does not support this image type: %s\n\nThe \`ecr-scan-results\` plugin will not supply useful results for this image: \`${IMAGE_NAME}\`" "${scan_status}")
+
+    echo "^^^ +++"
+    echo "${annotation}"
+
+    buildkite-agent annotate --style warning --context "exit_reason${IMAGE_LABEL_APP}" "${annotation}"
+
+    # not a blocking error
+    exit 0
+elif [[ "${scan_status}" != "COMPLETE" && "${scan_status}" != "ACTIVE" ]]; then
     annotation=$(printf "Error: ECR vulnerability scan failed with status: %s\n" "${scan_status}")
 
     echo "^^^ +++"


### PR DESCRIPTION
The status `UNSUPPORTED_IMAGE` means that the ECR scanning can't deal with the image: this should not be a reason to block a pipeline.

The fix on the consuming pipeline will probably be to discontinue use of the plugin, as it won't be adding value.
