### PR TITLE
Change pipeline blocking behaviour when scan fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Add the following lines to your `pipeline.yml`:
 
 ```yml
     plugins:
-      - cultureamp/ecr-scan-results#v1.1.4:
+      - cultureamp/ecr-scan-results#v1.1.7:
           image-name: "$BUILD_REPO:deploy-$BUILD_TAG"
 ```
 
@@ -23,7 +23,7 @@ steps:
     plugins:
       - cultureamp/aws-assume-role:
           role: ${BUILD_ROLE}
-      - cultureamp/ecr-scan-results#v1.1.4:
+      - cultureamp/ecr-scan-results#v1.1.7:
           image-name: "$BUILD_REPO:deploy-$BUILD_TAG"
 ```
 
@@ -38,7 +38,7 @@ steps:
     plugins:
       - cultureamp/aws-assume-role:
           role: ${BUILD_ROLE}
-      - cultureamp/ecr-scan-results#v1.1.4:
+      - cultureamp/ecr-scan-results#v1.1.7:
           image-name: "$BUILD_REPO:deploy-$BUILD_TAG"
           max-criticals: "1"
           max-highs: "10"
@@ -69,7 +69,7 @@ steps:
     plugins:
       cultureamp/aws-assume-role:
         role: ${DEV_BUILD_ROLE}
-        - cultureamp/ecr-scan-results#v1.1.4:
+        - cultureamp/ecr-scan-results#v1.1.7:
           image-name: "$DEV_BUILD_REPO:deploy-$DEV_BUILD_TAG"
           max-criticals: "2"
           max-highs: "20"
@@ -84,7 +84,7 @@ steps:
     plugins:
       cultureamp/aws-assume-role:
         role: ${MASTER_BUILD_ROLE}
-        - cultureamp/ecr-scan-results#v1.1.4:
+        - cultureamp/ecr-scan-results#v1.1.7:
           image-name: "$MASTER_BUILD_REPO:deploy-$MASTER_BUILD_TAG"
           max-criticals: "1"
           max-highs: "10"

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -160,7 +160,10 @@ if [[ "${scan_status}" == "UNSUPPORTED_IMAGE" ]]; then
     # not a blocking error
     exit 0
 elif [[ "${scan_status}" != "COMPLETE" && "${scan_status}" != "ACTIVE" ]]; then
-    annotation=$(printf "ECR vulnerability scan failed with status: %s\n\nVulnerability details not available." "${scan_status}")
+    annotation=$(printf "ECR vulnerability scan failed with status: %s.\n\nVulnerability details not available." "${scan_status}")
+    if [[ "${scan_status}" = "SCAN_NOT_PRESENT" ]]; then
+        annotation=$(printf "No ECR vulnerability scan available for image: \`%s\`\n\nThe results may be taking some time to report, or there may be an issue with scan configuration." "${IMAGE_NAME}")
+    fi
 
     echo "^^^ +++"
     echo "${annotation}"

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -113,10 +113,15 @@ echo "Using image digest: ${image_digest}"
 
 echo "--- waiting for scan results to be available..."
 
+# seconds to wait between attempts
+poll_wait=3
+# number of attempts
+poll_attempts=20
+
 # poll until scan is COMPLETE or FAILED
 scan_status="SCAN_NOT_PRESENT"
 i="0"
-while [[ "${scan_status}" = "SCAN_NOT_PRESENT" || "${scan_status}" = "IN_PROGRESS" || "${scan_status}" = "PENDING" ]]  && [ "$i" -le "20" ]
+while [[ "${scan_status}" = "SCAN_NOT_PRESENT" || "${scan_status}" = "IN_PROGRESS" || "${scan_status}" = "PENDING" ]]  && [ "$i" -le "${poll_attempts}" ]
 do
     echo "Poll attempt ${i}..."
     if ! scan_status="$(aws ecr describe-image-scan-findings \
@@ -139,7 +144,7 @@ do
     echo "scan status: ${scan_status}"
 
     # Give some time for the results to be available
-    [ "$i" != "0" ] && sleep 3
+    [ "$i" != "0" ] && sleep "${poll_wait}"
 
     ((i=i+1))
 done

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -167,7 +167,7 @@ elif [[ "${scan_status}" != "COMPLETE" && "${scan_status}" != "ACTIVE" ]]; then
 
     buildkite-agent annotate --style error --context "exit_reason${IMAGE_LABEL_APP}" "${annotation}"
 
-    exit 1
+    exit 0
 fi
 
 echo "scan complete"

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -160,12 +160,12 @@ if [[ "${scan_status}" == "UNSUPPORTED_IMAGE" ]]; then
     # not a blocking error
     exit 0
 elif [[ "${scan_status}" != "COMPLETE" && "${scan_status}" != "ACTIVE" ]]; then
-    annotation=$(printf "Error: ECR vulnerability scan failed with status: %s\n" "${scan_status}")
+    annotation=$(printf "ECR vulnerability scan failed with status: %s\n\nVulnerability details not available." "${scan_status}")
 
     echo "^^^ +++"
     echo "${annotation}"
 
-    buildkite-agent annotate --style error --context "exit_reason${IMAGE_LABEL_APP}" "${annotation}"
+    buildkite-agent annotate --style warning --context "exit_reason${IMAGE_LABEL_APP}" "${annotation}"
 
     exit 0
 fi


### PR DESCRIPTION
## Purpose

After changes to the scan configuration, the API is reporting that no scans are available for any images. This should not block pipelines.

This PR:

* removes any failure to find or produce a scan as a reason to block the pipeline
* improves plugin messaging when a scan isn't present
