### PR TITLE
fix: only download results when build succeeds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,6 @@ services:
       - ".:/plugin:ro"
 
   tests:
-    image: buildkite/plugin-tester:v4.0.0
+    image: buildkite/plugin-tester:v4.1.0
     volumes:
       - ".:/plugin"

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -3,6 +3,18 @@ set -euo pipefail
 
 dir="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
+command_status="${BUILDKITE_COMMAND_EXIT_STATUS:-0}"
+if [[ "${command_status}" != "0" ]]; then
+  # if the build has failed, the image won't be present: skip the check
+  echo "~~~ skipping ECR scan check on failed build"
+  exit 0
+fi
+
+if [[ "${BUILDKITE_PLUGIN_ECR_SCAN_RESULTS_BUILDKITE_PLUGIN_HOOK_TEST_MODE:-false}" = "true" ]]; then
+  echo "TEST: executing download"
+  exit 0
+fi
+
 # shellcheck source=lib/download.bash
 . "$dir/../lib/download.bash"
 

--- a/lib/download.bash
+++ b/lib/download.bash
@@ -84,16 +84,12 @@ download_binary_and_run() {
     _url=${_repo}/releases/download/${_version:1}/${_executable}_${_arch}
   fi
 
-#   local test_mode="${BUILDKITE_PLUGIN_ECR_SCAN_RESULTS_BUILDKITE_PLUGIN_TEST_MODE:-false}"
+  if ! downloader "$_url" "$_executable"; then
+    say "failed to download $_url"
+    exit 1
+  fi
 
-#   if [[ "$test_mode" == "false" ]]; then
-    if ! downloader "$_url" "$_executable"; then
-      say "failed to download $_url"
-      exit 1
-    fi
-
-    chmod +x ${_executable}
-#   fi
+  chmod +x ${_executable}
 
   ./${_executable}
 }

--- a/tests/download.bats
+++ b/tests/download.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-load '/usr/local/lib/bats/load.bash'
+load "${BATS_PLUGIN_PATH}/load.bash"
 
 load '../lib/download.bash'
 

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+
+load "${BATS_PLUGIN_PATH}/load.bash"
+
+#
+# Tests for pre-command hook
+#
+
+# Uncomment the following line to debug stub failures
+# export [stub_command]_STUB_DEBUG=/dev/tty
+#export DOCKER_STUB_DEBUG=/dev/tty
+
+setup() {
+  export BUILDKITE_PLUGIN_ECR_SCAN_RESULTS_BUILDKITE_PLUGIN_HOOK_TEST_MODE=true
+}
+
+teardown() {
+  unset BUILDKITE_PLUGIN_ECR_SCAN_RESULTS_BUILDKITE_PLUGIN_HOOK_TEST_MODE
+  unset BUILDKITE_COMMAND_EXIT_STATUS
+}
+
+@test "Executes scan when command has succeeded" {
+  export BUILDKITE_COMMAND_EXIT_STATUS=0
+  run "$PWD/hooks/post-command"
+
+  assert_success
+  assert_line --partial "TEST: executing download"
+}
+
+@test "Executes scan when command result not present" {
+  run "$PWD/hooks/post-command"
+
+  assert_success
+  assert_line --partial "TEST: executing download"
+}
+
+@test "Skips execution when build fails" {
+  export BUILDKITE_COMMAND_EXIT_STATUS=12
+  run "$PWD/hooks/post-command"
+
+  assert_success
+  assert_line --partial "skipping ECR scan check"
+}


### PR DESCRIPTION
Downloading results when the command has failed leads to distracting errors in the build UI and the build log, which make it harder to see the real issue for the failure.

It is possible that there is a case where this behaviour might be desirable: in that case we can add a variable to control it.