### PR TITLE
fix: sort descending by CVSS scores first

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,47 +8,47 @@ issues:
 linters:
   enable-all: true
   disable:
-  - gochecknoglobals
-  - wrapcheck
-  - varnamelen
-  - tagliatelle
-  - testpackage
-  - paralleltest
-  - gomnd
-  - goerr113
+  - asciicheck
   - depguard
   - dupl
-  - forbidigo
-  - funlen
-  - unparam
-  - wsl
   - errname
   - exhaustivestruct
   - exhaustruct
-  - nilnil
-  - nlreturn
-  - goconst
-  - lll
-  - asciicheck
+  - forbidigo
+  - funlen
+  - gochecknoglobals
   - gocognit
+  - goconst
   - godot
   - godox
+  - goerr113
   - gofumpt
+  - gomnd
+  - lll
+  - musttag
   - nestif
+  - nilnil
+  - nlreturn
+  - paralleltest
   - prealloc
   - revive
   - tagalign
+  - tagliatelle
+  - testpackage
+  - unparam
+  - varnamelen
   - whitespace
-  - musttag
+  - wrapcheck
+  - wsl
   # deprecated linters
-  - interfacer
-  - golint
-  - scopelint
-  - maligned
   - deadcode
+  - golint
   - ifshort
-  - structcheck
+  - interfacer
+  - maligned
   - nosnakecase
+  - scopelint
+  - structcheck
   - varcheck
 
 linters-settings:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,7 @@ linters:
   - exhaustruct
   - forbidigo
   - funlen
+  - gci
   - gochecknoglobals
   - gocognit
   - goconst

--- a/src/finding/summary.go
+++ b/src/finding/summary.go
@@ -223,11 +223,7 @@ func convertScore(s string) *decimal.Decimal {
 	}
 
 	d, err := decimal.NewFromString(s)
-	if err != nil {
-		return nil
-	}
-
-	if d.LessThanOrEqual(decimal.Decimal{}) {
+	if err != nil || d.LessThanOrEqual(decimal.Decimal{}) {
 		return nil
 	}
 

--- a/src/finding/summary.go
+++ b/src/finding/summary.go
@@ -164,15 +164,18 @@ func findingAttributeValue(finding types.ImageScanFinding, name string) string {
 	return ""
 }
 
-const legacyCVEURL = "https://cve.mitre.org/cgi-bin/cvename.cgi?name="
+// deprecatedCVEURL is the format of the now-deprecated cve.mitre.org CVE URLs.
+// While findings still refer to this source, it's in the process of being
+// retired and displays a warning when visited.
+const deprecatedCVEURL = "https://cve.mitre.org/cgi-bin/cvename.cgi?name="
 const updatedCVEURL = "https://www.cve.org/CVERecord?id="
 
 func fixFindingURI(name string, uri string) string {
 	correctedURI := uri
 
 	// transition from the old CVE site that is deprecated
-	if strings.HasPrefix(correctedURI, legacyCVEURL) {
-		correctedURI = strings.Replace(correctedURI, legacyCVEURL, updatedCVEURL, 1)
+	if strings.HasPrefix(correctedURI, deprecatedCVEURL) {
+		correctedURI = strings.Replace(correctedURI, deprecatedCVEURL, updatedCVEURL, 1)
 	}
 
 	// sometimes links are published that are not valid: in this case point to a

--- a/src/finding/summary.go
+++ b/src/finding/summary.go
@@ -185,21 +185,21 @@ func cvss2VectorURL(cvss2Vector string) string {
 var cvss3VectorPattern = regexp.MustCompile(`^CVSS:([\d.]+)/(.+)$`)
 
 func cvss3VectorURL(versionedVector string) (string, string) {
-	vector := versionedVector
-	vectorURL := ""
-
-	if versionedVector != "" {
-		version := "3.1"
-
-		if matches := cvss3VectorPattern.FindStringSubmatch(versionedVector); matches != nil {
-			version = matches[1]
-			vector = matches[2]
-		}
-
-		vectorURL = "https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator" +
-			"?vector=" + url.QueryEscape(vector) +
-			"&version=" + url.QueryEscape(version)
+	if versionedVector == "" {
+		return "", ""
 	}
+
+	vector := versionedVector
+	version := "3.1"
+
+	if matches := cvss3VectorPattern.FindStringSubmatch(versionedVector); matches != nil {
+		version = matches[1]
+		vector = matches[2]
+	}
+
+	vectorURL := "https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator" +
+		"?vector=" + url.QueryEscape(vector) +
+		"&version=" + url.QueryEscape(version)
 
 	return vector, vectorURL
 }

--- a/src/finding/summary_test.go
+++ b/src/finding/summary_test.go
@@ -12,22 +12,13 @@ import (
 
 func TestSummarize(t *testing.T) {
 	cases := []struct {
-		name     string
-		ignores  []findingconfig.Ignore
-		data     types.ImageScanFindings
-		expected autogold.Value
+		name    string
+		ignores []findingconfig.Ignore
+		data    types.ImageScanFindings
 	}{
 		{
 			name: "no vulnerabilities",
 			data: types.ImageScanFindings{},
-			expected: autogold.Expect(finding.Summary{
-				Counts: map[types.FindingSeverity]finding.SeverityCount{
-					types.FindingSeverity("CRITICAL"): {},
-					types.FindingSeverity("HIGH"):     {},
-				},
-				Details: []finding.Detail{},
-				Ignored: []finding.Detail{},
-			}),
 		},
 		{
 			name: "findings with links",
@@ -38,30 +29,6 @@ func TestSummarize(t *testing.T) {
 					fu("CVE-2019-5189", "HIGH", "https://notamitre.org.site/search?name=CVE-2019-5189"),
 				},
 			},
-			expected: autogold.Expect(finding.Summary{
-				Counts: map[types.FindingSeverity]finding.SeverityCount{
-					types.FindingSeverity("CRITICAL"): {Included: 1},
-					types.FindingSeverity("HIGH"):     {Included: 2},
-				},
-				Details: []finding.Detail{
-					{
-						Name:     "CVE-2019-5188",
-						URI:      "https://www.cve.org/CVERecord?id=CVE-2019-5188",
-						Severity: types.FindingSeverity("HIGH"),
-					},
-					{
-						Name:     "INVALID-CVE",
-						URI:      "https://github.com/advisories?query=INVALID-CVE",
-						Severity: types.FindingSeverity("CRITICAL"),
-					},
-					{
-						Name:     "CVE-2019-5189",
-						URI:      "https://notamitre.org.site/search?name=CVE-2019-5189",
-						Severity: types.FindingSeverity("HIGH"),
-					},
-				},
-				Ignored: []finding.Detail{},
-			}),
 		},
 		{
 			name: "findings with CVSS2 and CVSS3 scores",
@@ -73,42 +40,6 @@ func TestSummarize(t *testing.T) {
 					fscore3("CVE-2019-5189", "HIGH", "9", "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N"),
 				},
 			},
-			expected: autogold.Expect(finding.Summary{
-				Counts: map[types.FindingSeverity]finding.SeverityCount{
-					types.FindingSeverity("CRITICAL"): {Included: 1},
-					types.FindingSeverity("HIGH"):     {Included: 3},
-				},
-				Details: []finding.Detail{
-					{
-						Name:     "CVE-2019-5188",
-						Severity: types.FindingSeverity("HIGH"),
-						CVSS2: finding.CVSSScore{
-							Score:     "1.2",
-							Vector:    "AV:L/AC:L/Au:N/C:P/I:P/A:P",
-							VectorURL: "https://nvd.nist.gov/vuln-metrics/cvss/v2-calculator?vector=%28AV%3AL%2FAC%3AL%2FAu%3AN%2FC%3AP%2FI%3AP%2FA%3AP%29",
-						},
-					},
-					{
-						Name:     "INVALID-CVE",
-						Severity: types.FindingSeverity("CRITICAL"),
-					},
-					{
-						Name:     "CVE-2019-5189",
-						Severity: types.FindingSeverity("HIGH"),
-						CVSS2:    finding.CVSSScore{Score: "6"},
-					},
-					{
-						Name:     "CVE-2019-5189",
-						Severity: types.FindingSeverity("HIGH"),
-						CVSS3: finding.CVSSScore{
-							Score:     "9",
-							Vector:    "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N",
-							VectorURL: "https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV%3AN%2FAC%3AL%2FPR%3AN%2FUI%3AN%2FS%3AU%2FC%3AH%2FI%3AH%2FA%3AN&version=3.1",
-						},
-					},
-				},
-				Ignored: []finding.Detail{},
-			}),
 		},
 		{
 			name: "findings with no ignores",
@@ -119,27 +50,6 @@ func TestSummarize(t *testing.T) {
 					f("CVE-2019-5189", "HIGH"),
 				},
 			},
-			expected: autogold.Expect(finding.Summary{
-				Counts: map[types.FindingSeverity]finding.SeverityCount{
-					types.FindingSeverity("CRITICAL"): {Included: 1},
-					types.FindingSeverity("HIGH"):     {Included: 2},
-				},
-				Details: []finding.Detail{
-					{
-						Name:     "CVE-2019-5188",
-						Severity: types.FindingSeverity("HIGH"),
-					},
-					{
-						Name:     "CVE-2019-5200",
-						Severity: types.FindingSeverity("CRITICAL"),
-					},
-					{
-						Name:     "CVE-2019-5189",
-						Severity: types.FindingSeverity("HIGH"),
-					},
-				},
-				Ignored: []finding.Detail{},
-			}),
 		},
 		{
 			name: "ignores affect counts",
@@ -154,32 +64,6 @@ func TestSummarize(t *testing.T) {
 				i("CVE-2019-5189"), // part of the summary
 				i("CVE-2019-6000"), // not part of it
 			},
-			expected: autogold.Expect(finding.Summary{
-				Counts: map[types.FindingSeverity]finding.SeverityCount{
-					types.FindingSeverity("CRITICAL"): {Included: 1},
-					types.FindingSeverity("HIGH"): {
-						Included: 1,
-						Ignored:  1,
-					},
-				},
-				Details: []finding.Detail{
-					{
-						Name:     "CVE-2019-5188",
-						Severity: types.FindingSeverity("HIGH"),
-					},
-					{
-						Name:     "CVE-2019-5200",
-						Severity: types.FindingSeverity("CRITICAL"),
-					},
-				},
-				Ignored: []finding.Detail{{
-					Name:     "CVE-2019-5189",
-					Severity: types.FindingSeverity("HIGH"),
-					Ignore: &findingconfig.Ignore{
-						ID: "CVE-2019-5189",
-					},
-				}},
-			}),
 		},
 	}
 
@@ -188,7 +72,7 @@ func TestSummarize(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			summary := finding.Summarize(&c.data, c.ignores)
 
-			c.expected.Equal(t, summary)
+			autogold.ExpectFile(t, summary)
 		})
 	}
 }

--- a/src/finding/testdata/TestSummarize/findings_with_CVSS2_and_CVSS3_scores.golden
+++ b/src/finding/testdata/TestSummarize/findings_with_CVSS2_and_CVSS3_scores.golden
@@ -8,7 +8,12 @@ finding.Summary{
 			Name:     "CVE-2019-5188",
 			Severity: types.FindingSeverity("HIGH"),
 			CVSS2: finding.CVSSScore{
-				Score:     "1.2",
+				Score: &decimal.Decimal{
+					value: &big.Int{
+						abs: big.nat{big.Word(12)},
+					},
+					exp: -1,
+				},
 				Vector:    "AV:L/AC:L/Au:N/C:P/I:P/A:P",
 				VectorURL: "https://nvd.nist.gov/vuln-metrics/cvss/v2-calculator?vector=%28AV%3AL%2FAC%3AL%2FAu%3AN%2FC%3AP%2FI%3AP%2FA%3AP%29",
 			},
@@ -20,13 +25,13 @@ finding.Summary{
 		{
 			Name:     "CVE-2019-5189",
 			Severity: types.FindingSeverity("HIGH"),
-			CVSS2:    finding.CVSSScore{Score: "6"},
+			CVSS2:    finding.CVSSScore{Score: &decimal.Decimal{value: &big.Int{abs: big.nat{big.Word(6)}}}},
 		},
 		{
 			Name:     "CVE-2019-5189",
 			Severity: types.FindingSeverity("HIGH"),
 			CVSS3: finding.CVSSScore{
-				Score:     "9",
+				Score:     &decimal.Decimal{value: &big.Int{abs: big.nat{big.Word(9)}}},
 				Vector:    "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N",
 				VectorURL: "https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV%3AN%2FAC%3AL%2FPR%3AN%2FUI%3AN%2FS%3AU%2FC%3AH%2FI%3AH%2FA%3AN&version=3.1",
 			},

--- a/src/finding/testdata/TestSummarize/findings_with_CVSS2_and_CVSS3_scores.golden
+++ b/src/finding/testdata/TestSummarize/findings_with_CVSS2_and_CVSS3_scores.golden
@@ -1,0 +1,36 @@
+finding.Summary{
+	Counts: map[types.FindingSeverity]finding.SeverityCount{
+		types.FindingSeverity("CRITICAL"): {Included: 1},
+		types.FindingSeverity("HIGH"):     {Included: 3},
+	},
+	Details: []finding.Detail{
+		{
+			Name:     "CVE-2019-5188",
+			Severity: types.FindingSeverity("HIGH"),
+			CVSS2: finding.CVSSScore{
+				Score:     "1.2",
+				Vector:    "AV:L/AC:L/Au:N/C:P/I:P/A:P",
+				VectorURL: "https://nvd.nist.gov/vuln-metrics/cvss/v2-calculator?vector=%28AV%3AL%2FAC%3AL%2FAu%3AN%2FC%3AP%2FI%3AP%2FA%3AP%29",
+			},
+		},
+		{
+			Name:     "INVALID-CVE",
+			Severity: types.FindingSeverity("CRITICAL"),
+		},
+		{
+			Name:     "CVE-2019-5189",
+			Severity: types.FindingSeverity("HIGH"),
+			CVSS2:    finding.CVSSScore{Score: "6"},
+		},
+		{
+			Name:     "CVE-2019-5189",
+			Severity: types.FindingSeverity("HIGH"),
+			CVSS3: finding.CVSSScore{
+				Score:     "9",
+				Vector:    "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N",
+				VectorURL: "https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV%3AN%2FAC%3AL%2FPR%3AN%2FUI%3AN%2FS%3AU%2FC%3AH%2FI%3AH%2FA%3AN&version=3.1",
+			},
+		},
+	},
+	Ignored: []finding.Detail{},
+}

--- a/src/finding/testdata/TestSummarize/findings_with_links.golden
+++ b/src/finding/testdata/TestSummarize/findings_with_links.golden
@@ -1,0 +1,24 @@
+finding.Summary{
+	Counts: map[types.FindingSeverity]finding.SeverityCount{
+		types.FindingSeverity("CRITICAL"): {Included: 1},
+		types.FindingSeverity("HIGH"):     {Included: 2},
+	},
+	Details: []finding.Detail{
+		{
+			Name:     "CVE-2019-5188",
+			URI:      "https://www.cve.org/CVERecord?id=CVE-2019-5188",
+			Severity: types.FindingSeverity("HIGH"),
+		},
+		{
+			Name:     "INVALID-CVE",
+			URI:      "https://github.com/advisories?query=INVALID-CVE",
+			Severity: types.FindingSeverity("CRITICAL"),
+		},
+		{
+			Name:     "CVE-2019-5189",
+			URI:      "https://notamitre.org.site/search?name=CVE-2019-5189",
+			Severity: types.FindingSeverity("HIGH"),
+		},
+	},
+	Ignored: []finding.Detail{},
+}

--- a/src/finding/testdata/TestSummarize/findings_with_no_ignores.golden
+++ b/src/finding/testdata/TestSummarize/findings_with_no_ignores.golden
@@ -1,0 +1,21 @@
+finding.Summary{
+	Counts: map[types.FindingSeverity]finding.SeverityCount{
+		types.FindingSeverity("CRITICAL"): {Included: 1},
+		types.FindingSeverity("HIGH"):     {Included: 2},
+	},
+	Details: []finding.Detail{
+		{
+			Name:     "CVE-2019-5188",
+			Severity: types.FindingSeverity("HIGH"),
+		},
+		{
+			Name:     "CVE-2019-5200",
+			Severity: types.FindingSeverity("CRITICAL"),
+		},
+		{
+			Name:     "CVE-2019-5189",
+			Severity: types.FindingSeverity("HIGH"),
+		},
+	},
+	Ignored: []finding.Detail{},
+}

--- a/src/finding/testdata/TestSummarize/ignores_affect_counts.golden
+++ b/src/finding/testdata/TestSummarize/ignores_affect_counts.golden
@@ -1,0 +1,26 @@
+finding.Summary{
+	Counts: map[types.FindingSeverity]finding.SeverityCount{
+		types.FindingSeverity("CRITICAL"): {Included: 1},
+		types.FindingSeverity("HIGH"): {
+			Included: 1,
+			Ignored:  1,
+		},
+	},
+	Details: []finding.Detail{
+		{
+			Name:     "CVE-2019-5188",
+			Severity: types.FindingSeverity("HIGH"),
+		},
+		{
+			Name:     "CVE-2019-5200",
+			Severity: types.FindingSeverity("CRITICAL"),
+		},
+	},
+	Ignored: []finding.Detail{{
+		Name:     "CVE-2019-5189",
+		Severity: types.FindingSeverity("HIGH"),
+		Ignore: &findingconfig.Ignore{
+			ID: "CVE-2019-5189",
+		},
+	}},
+}

--- a/src/finding/testdata/TestSummarize/no_vulnerabilities.golden
+++ b/src/finding/testdata/TestSummarize/no_vulnerabilities.golden
@@ -1,0 +1,8 @@
+finding.Summary{
+	Counts: map[types.FindingSeverity]finding.SeverityCount{
+		types.FindingSeverity("CRITICAL"): {},
+		types.FindingSeverity("HIGH"):     {},
+	},
+	Details: []finding.Detail{},
+	Ignored: []finding.Detail{},
+}

--- a/src/go.mod
+++ b/src/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/hexops/autogold/v2 v2.2.1
 	github.com/justincampbell/timeago v0.0.0-20160528003754-027f40306f1d
 	github.com/kelseyhightower/envconfig v1.4.0
+	github.com/shopspring/decimal v1.3.1
 	github.com/stretchr/testify v1.8.0
 	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa
 

--- a/src/go.sum
+++ b/src/go.sum
@@ -86,6 +86,8 @@ github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
+github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
+github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/src/report/annotation.go
+++ b/src/report/annotation.go
@@ -152,7 +152,7 @@ func rankSeverity(f types.FindingSeverity) int {
 
 func compareCVSSScore(a, b finding.CVSSScore) int {
 	switch {
-	case a.Score == nil && b.Score == nil:
+	case a.Score == b.Score:
 		return 0
 	case a.Score == nil:
 		return -1

--- a/src/report/annotation.gohtml
+++ b/src/report/annotation.gohtml
@@ -47,7 +47,7 @@ be wrapped in <p> tag by the Markdown renderer in Buildkite.
 {{ define "cvssCells" }}
 {{ if .CVSS3.Score }}<td>{{ template "cvssScore" .CVSS3 }}</td><td>{{ template "cvssVector" .CVSS3 }}</td>{{
    else
-}}<td>{{ if .CVSS2.Score }}{{ template "cvssScore" .CVSS2 }} <em>(*CVSS2)</em>{{ end }}</td><td>{{ template "cvssVector" .CVSS2 }}</td>{{ end }}
+}}<td>{{ if .CVSS2.Score }}{{ template "cvssScore" .CVSS2 }} <em>(*CVSS2)</em>{{ else }}&nbsp;{{ end }}</td><td>{{ template "cvssVector" .CVSS2 }}</td>{{ end }}
 {{ end }}
 {{ if (or .FindingSummary.Details .FindingSummary.Ignored) }}
 <details>

--- a/src/report/annotation.gohtml
+++ b/src/report/annotation.gohtml
@@ -42,7 +42,7 @@ be wrapped in <p> tag by the Markdown renderer in Buildkite.
 {{ define "findingName" }}{{ if .Description }}<details><summary>{{ template "findingNameLink" . }}</summary><div>{{ .Description }}</div></details>{{ else }}{{ template "findingNameLink" . }}{{ end }}{{ end }}
 {{ define "findingIgnoreUntil" }}{{ if .Until | hasUntilValue }}{{ .Until }}{{ else }}<div class="italic">(indefinitely)</div>{{ end }}{{ end }}
 {{ define "findingIgnore"}}{{ if .Reason }}<details><summary>{{ template "findingIgnoreUntil" . }}</summary><div>{{ .Reason }}</div></details>{{ else }}{{ template "findingIgnoreUntil" . }}{{ end }}{{ end }}
-{{ define "cvssScore" }}{{ .Score | nbsp}}{{ end }}
+{{ define "cvssScore" }}{{ .Score.StringFixed 1 | nbsp}}{{ end }}
 {{ define "cvssVector" }}{{ if .Vector }}<a href="{{ .VectorURL }}">{{ .Vector }}</a>{{ else }}&nbsp;{{end}}{{ end }}
 {{ define "cvssCells" }}
 {{ if .CVSS3.Score }}<td>{{ template "cvssScore" .CVSS3 }}</td><td>{{ template "cvssVector" .CVSS3 }}</td>{{

--- a/src/report/annotation_function_test.go
+++ b/src/report/annotation_function_test.go
@@ -33,3 +33,56 @@ func TestSortSeverities(t *testing.T) {
 
 	assert.Equal(t, expected, actual)
 }
+
+func TestCompareCVSSScore(t *testing.T) {
+	tests := []struct {
+		name     string
+		a, b     string
+		expected int
+	}{
+		{
+			name:     "equal",
+			a:        "10",
+			b:        "10.0",
+			expected: 0,
+		},
+		{
+			name:     "a is greater",
+			a:        "10",
+			b:        "9.9",
+			expected: 1,
+		},
+		{
+			name:     "b is greater",
+			a:        "5",
+			b:        "10",
+			expected: -1,
+		},
+		{
+			name:     "both nil",
+			a:        "",
+			b:        "",
+			expected: 0,
+		},
+		{
+			name:     "only a nil",
+			a:        "",
+			b:        "10",
+			expected: -1,
+		},
+		{
+			name:     "only b nil",
+			a:        "5",
+			b:        "",
+			expected: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			actual := compareCVSSScore(finding.NewCVSS2Score(test.a, ""), finding.NewCVSS2Score(test.b, ""))
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}

--- a/src/report/annotation_test.go
+++ b/src/report/annotation_test.go
@@ -70,11 +70,10 @@ func TestReports(t *testing.T) {
 							Severity:       "AA-BOGUS-SEVERITY",
 							PackageName:    "5300-package",
 							PackageVersion: "5300-version",
-							CVSS2: finding.CVSSScore{
-								Score:     "10.0",
-								Vector:    "AV:L/AC:L/Au:N/C:P/I:P/A:P",
-								VectorURL: "https://nvd.nist.gov/vuln-metrics/cvss/v2-calculator?vector=%28AV%3AL%2FAC%3AL%2FAu%3AN%2FC%3AP%2FI%3AP%2FA%3AP%29",
-							},
+							CVSS2: finding.NewCVSS2Score(
+								"10.0",
+								"AV:L/AC:L/Au:N/C:P/I:P/A:P",
+							),
 						},
 						{
 							Name:           "CVE-2019-5188",
@@ -83,16 +82,14 @@ func TestReports(t *testing.T) {
 							Severity:       "HIGH",
 							PackageName:    "e2fsprogs",
 							PackageVersion: "1.44.1-1ubuntu1.1",
-							CVSS2: finding.CVSSScore{
-								Score:     "4.6",
-								Vector:    "AV:L/AC:L/Au:N/C:P/I:P/A:P",
-								VectorURL: "https://nvd.nist.gov/vuln-metrics/cvss/v2-calculator?vector=%28AV%3AL%2FAC%3AL%2FAu%3AN%2FC%3AP%2FI%3AP%2FA%3AP%29",
-							},
-							CVSS3: finding.CVSSScore{
-								Score:     "9",
-								Vector:    "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N",
-								VectorURL: "https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV%3AN%2FAC%3AL%2FPR%3AN%2FUI%3AN%2FS%3AU%2FC%3AH%2FI%3AH%2FA%3AN&version=3.1",
-							},
+							CVSS2: finding.NewCVSS2Score(
+								"4.6",
+								"AV:L/AC:L/Au:N/C:P/I:P/A:P",
+							),
+							CVSS3: finding.NewCVSS3Score(
+								"9",
+								"AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N",
+							),
 						},
 						{
 							Name:           "CVE-2019-5200",
@@ -101,11 +98,10 @@ func TestReports(t *testing.T) {
 							Severity:       "CRITICAL",
 							PackageName:    "5200-package",
 							PackageVersion: "5200-version",
-							CVSS2: finding.CVSSScore{
-								Score:     "10.0",
-								Vector:    "AV:L/AC:L/Au:N/C:P/I:P/A:P",
-								VectorURL: "https://nvd.nist.gov/vuln-metrics/cvss/v2-calculator?vector=%28AV%3AL%2FAC%3AL%2FAu%3AN%2FC%3AP%2FI%3AP%2FA%3AP%29",
-							},
+							CVSS2: finding.NewCVSS2Score(
+								"10.0",
+								"AV:L/AC:L/Au:N/C:P/I:P/A:P",
+							),
 						},
 					},
 				},
@@ -137,11 +133,10 @@ func TestReports(t *testing.T) {
 							Severity:       "HIGH",
 							PackageName:    "e2fsprogs",
 							PackageVersion: "1.44.1-1ubuntu1.1",
-							CVSS2: finding.CVSSScore{
-								Score:     "4.6",
-								Vector:    "AV:L/AC:L/Au:N/C:P/I:P/A:P",
-								VectorURL: "https://nvd.nist.gov/vuln-metrics/cvss/v2-calculator?vector=%28AV%3AL%2FAC%3AL%2FAu%3AN%2FC%3AP%2FI%3AP%2FA%3AP%29",
-							},
+							CVSS2: finding.NewCVSS2Score(
+								"4.6",
+								"AV:L/AC:L/Au:N/C:P/I:P/A:P",
+							),
 						},
 						{
 							Name:           "CVE-2019-5200",
@@ -150,11 +145,10 @@ func TestReports(t *testing.T) {
 							Severity:       "CRITICAL",
 							PackageName:    "5200-package",
 							PackageVersion: "5200-version",
-							CVSS2: finding.CVSSScore{
-								Score:     "10.0",
-								Vector:    "AV:L/AC:L/Au:N/C:P/I:P/A:P",
-								VectorURL: "https://nvd.nist.gov/vuln-metrics/cvss/v2-calculator?vector=%28AV%3AL%2FAC%3AL%2FAu%3AN%2FC%3AP%2FI%3AP%2FA%3AP%29",
-							},
+							CVSS2: finding.NewCVSS2Score(
+								"10.0",
+								"AV:L/AC:L/Au:N/C:P/I:P/A:P",
+							),
 						},
 					},
 					Ignored: []finding.Detail{
@@ -165,11 +159,10 @@ func TestReports(t *testing.T) {
 							Severity:       "LOW",
 							PackageName:    "100-package",
 							PackageVersion: "100-version",
-							CVSS2: finding.CVSSScore{
-								Score:     "4.0",
-								Vector:    "AV:L/AC:L/Au:N/C:P/I:P/A:P",
-								VectorURL: "https://nvd.nist.gov/vuln-metrics/cvss/v2-calculator?vector=%28AV%3AL%2FAC%3AL%2FAu%3AN%2FC%3AP%2FI%3AP%2FA%3AP%29",
-							},
+							CVSS2: finding.NewCVSS2Score(
+								"4.0",
+								"AV:L/AC:L/Au:N/C:P/I:P/A:P",
+							),
 							Ignore: &findingconfig.Ignore{
 								ID: "CVE-2023-100",
 							},
@@ -181,15 +174,14 @@ func TestReports(t *testing.T) {
 							Severity:       "CRITICAL",
 							PackageName:    "5300-package",
 							PackageVersion: "5300-version",
-							CVSS2: finding.CVSSScore{
-								Score:  "10.0",
-								Vector: "AV:L/AC:L/Au:N/C:P/I:P/A:P",
-							},
-							CVSS3: finding.CVSSScore{
-								Score:     "9",
-								Vector:    "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N",
-								VectorURL: "https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV%3AN%2FAC%3AL%2FPR%3AN%2FUI%3AN%2FS%3AU%2FC%3AH%2FI%3AH%2FA%3AN&version=3.1",
-							},
+							CVSS2: finding.NewCVSS2Score(
+								"10.0",
+								"AV:L/AC:L/Au:N/C:P/I:P/A:P",
+							),
+							CVSS3: finding.NewCVSS3Score(
+								"9",
+								"AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N",
+							),
 							Ignore: &findingconfig.Ignore{
 								ID:     "CVE-2019-5300",
 								Until:  findingconfig.MustParseUntil("2023-12-31"),

--- a/src/report/annotation_test.go
+++ b/src/report/annotation_test.go
@@ -193,7 +193,66 @@ func TestReports(t *testing.T) {
 				CriticalSeverityThreshold: 0,
 				HighSeverityThreshold:     0,
 			},
-		}}
+		},
+		{
+			name: "sorted findings",
+			data: report.AnnotationContext{
+				Image: registry.RegistryInfo{
+					RegistryID: "0123456789",
+					Region:     "us-west-2",
+					Name:       "test-repo",
+					Tag:        "digest-value",
+				},
+				ImageLabel: "label of image",
+				FindingSummary: finding.Summary{
+					Counts: map[types.FindingSeverity]finding.SeverityCount{
+						"HIGH":     {Included: 1},
+						"CRITICAL": {Included: 1, Ignored: 1},
+						"LOW":      {Included: 0, Ignored: 1},
+					},
+					Details: []finding.Detail{
+						{
+							Name:     "CVE-a",
+							Severity: "HIGH",
+							CVSS3:    finding.NewCVSS3Score("5.0", ""),
+							CVSS2:    finding.NewCVSS2Score("5.0", ""),
+						},
+						{
+							Name:     "CVE-b",
+							Severity: "HIGH",
+						},
+						{
+							Name:     "CVE-c",
+							Severity: "HIGH",
+						},
+						{
+							Name:     "CVE-d",
+							Severity: "HIGH",
+							CVSS2:    finding.NewCVSS2Score("6.0", ""),
+						},
+						{
+							Name:     "CVE-f",
+							Severity: "HIGH",
+							CVSS3:    finding.NewCVSS3Score("6.0", ""),
+							CVSS2:    finding.NewCVSS2Score("4.0", ""),
+						},
+						{
+							Name:     "CVE-g",
+							Severity: "HIGH",
+							CVSS2:    finding.NewCVSS3Score("8.0", ""),
+						},
+						{
+							Name:     "CVE-h",
+							Severity: "HIGH",
+							CVSS3:    finding.NewCVSS2Score("9.0", ""),
+						},
+					},
+				},
+				CriticalSeverityThreshold: 0,
+				HighSeverityThreshold:     0,
+			},
+		},
+	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/src/report/testdata/TestReports/findings_included.golden
+++ b/src/report/testdata/TestReports/findings_included.golden
@@ -75,7 +75,7 @@
 <td>High</td>
 <td>e2fsprogs 1.44.1-1ubuntu1.1</td>
 
-<td>9</td><td><a href="https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV%3AN%2FAC%3AL%2FPR%3AN%2FUI%3AN%2FS%3AU%2FC%3AH%2FI%3AH%2FA%3AN&amp;version=3.1">AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N</a></td>
+<td>9.0</td><td><a href="https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV%3AN%2FAC%3AL%2FPR%3AN%2FUI%3AN%2FS%3AU%2FC%3AH%2FI%3AH%2FA%3AN&amp;version=3.1">AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N</a></td>
 
 </tr>
 

--- a/src/report/testdata/TestReports/some_findings_ignored.golden
+++ b/src/report/testdata/TestReports/some_findings_ignored.golden
@@ -101,7 +101,7 @@
 <td><details><summary>2023-12-31</summary><div>Ignored to give the base image a chance to be updated</div></details></td>
 <td>5300-package 5300-version</td>
 
-<td>9</td><td><a href="https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV%3AN%2FAC%3AL%2FPR%3AN%2FUI%3AN%2FS%3AU%2FC%3AH%2FI%3AH%2FA%3AN&amp;version=3.1">AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N</a></td>
+<td>9.0</td><td><a href="https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV%3AN%2FAC%3AL%2FPR%3AN%2FUI%3AN%2FS%3AU%2FC%3AH%2FI%3AH%2FA%3AN&amp;version=3.1">AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N</a></td>
 
 </tr>
 

--- a/src/report/testdata/TestReports/sorted_findings.golden
+++ b/src/report/testdata/TestReports/sorted_findings.golden
@@ -1,0 +1,137 @@
+`
+
+
+
+
+<h4>Vulnerability summary for "label of image"</h4>
+<p class="h6 regular italic">test-repo:digest-value</p>
+
+
+<dl class="flex flex-wrap mxn1">
+
+
+
+
+<div class="m1 p1 mr3">
+<dt>Critical</dt>
+<dd><h1 class="m0 red">1</h1>
+<em>+ 1 ignored</em>
+</dd>
+</div>
+
+
+
+<div class="m1 p1 mr3">
+<dt>High</dt>
+<dd><h1 class="m0 red">1</h1>
+
+</dd>
+</div>
+
+
+
+<div class="m1 p1 mr3">
+<dt>Low</dt>
+<dd><h1 class="m0">0</h1>
+<em>+ 1 ignored</em>
+</dd>
+</div>
+
+</dl>
+
+
+
+
+
+
+
+
+
+<details>
+<summary>Vulnerability details</summary>
+<div>
+<p>All listed scores are CVSS3 unless otherwise noted.</p>
+
+<table>
+<tr>
+<th>CVE</th>
+<th>Severity</th>
+<th>Affects</th>
+<th>CVSS score</th>
+<th>CVSS vector</th>
+</tr>
+
+<tr>
+<td>CVE-h</td>
+<td>High</td>
+<td>&nbsp; &nbsp;</td>
+
+<td>9.0</td><td>&nbsp;</td>
+
+</tr>
+
+<tr>
+<td>CVE-f</td>
+<td>High</td>
+<td>&nbsp; &nbsp;</td>
+
+<td>6.0</td><td>&nbsp;</td>
+
+</tr>
+
+<tr>
+<td>CVE-a</td>
+<td>High</td>
+<td>&nbsp; &nbsp;</td>
+
+<td>5.0</td><td>&nbsp;</td>
+
+</tr>
+
+<tr>
+<td>CVE-g</td>
+<td>High</td>
+<td>&nbsp; &nbsp;</td>
+
+<td>8.0 <em>(*CVSS2)</em></td><td>&nbsp;</td>
+
+</tr>
+
+<tr>
+<td>CVE-d</td>
+<td>High</td>
+<td>&nbsp; &nbsp;</td>
+
+<td>6.0 <em>(*CVSS2)</em></td><td>&nbsp;</td>
+
+</tr>
+
+<tr>
+<td>CVE-c</td>
+<td>High</td>
+<td>&nbsp; &nbsp;</td>
+
+<td>&nbsp;</td><td>&nbsp;</td>
+
+</tr>
+
+<tr>
+<td>CVE-b</td>
+<td>High</td>
+<td>&nbsp; &nbsp;</td>
+
+<td>&nbsp;</td><td>&nbsp;</td>
+
+</tr>
+
+</table>
+
+
+</div>
+</details>
+
+<p class="p1">
+<i>scan completed: <span title="&lt;nil&gt;"></span></i> |
+<i>source updated: <span title="&lt;nil&gt;"></span></i>
+</p>
+`


### PR DESCRIPTION
> [!TIP]
> This PR reads commit-by-commit

Based on CVSS3 support added in #26. 

Leads to more readily understandable annotations as the most critical are rendered higher.

CVSS3 and CVSS2 schemes are sorted separately because their scoring outcomes are not comparable. This means that in longer lists, CVSS2 results are pushed down the page, however considering that AWS is moving away from CVSS2 and few images have such a massive pile of issues it's probably the right trade-off.

Sort is by:
- severity rank, then
- CVSS3 score desc
- CVSS2 score desc
- CVE name desc

Example:
<img width="895" alt="image" src="https://github.com/cultureamp/ecr-scan-results-buildkite-plugin/assets/792299/a6317def-b0c7-4431-b351-bf524066e389">
