### PR TITLE
fix: allow ignore reason to render as Markdown

### DIFF
--- a/docs/ignore-findings.md
+++ b/docs/ignore-findings.md
@@ -7,7 +7,8 @@ ignores:
   - id: CVE-2023-100
   - id: CVE-2023-200
     until: 2023-12-31
-    reason: allowing 2 weeks for base image to update
+    reason: |
+      Allowing 2 weeks for [base image](https://google.com) to update. Markdown is allowed!
   - id: CVE-2023-300
 ```
 

--- a/src/report/annotation.gohtml
+++ b/src/report/annotation.gohtml
@@ -41,7 +41,12 @@ be wrapped in <p> tag by the Markdown renderer in Buildkite.
 {{ define "findingNameLink" }}{{ if .URI }}<a href="{{ .URI }}">{{ .Name }}</a>{{ else }}{{ .Name }}{{ end }}{{ end }}
 {{ define "findingName" }}{{ if .Description }}<details><summary>{{ template "findingNameLink" . }}</summary><div>{{ .Description }}</div></details>{{ else }}{{ template "findingNameLink" . }}{{ end }}{{ end }}
 {{ define "findingIgnoreUntil" }}{{ if .Until | hasUntilValue }}{{ .Until }}{{ else }}<div class="italic">(indefinitely)</div>{{ end }}{{ end }}
-{{ define "findingIgnore"}}{{ if .Reason }}<details><summary>{{ template "findingIgnoreUntil" . }}</summary><div>{{ .Reason }}</div></details>{{ else }}{{ template "findingIgnoreUntil" . }}{{ end }}{{ end }}
+{{ define "findingIgnore"}}{{ if .Reason }}<details><summary>{{ template "findingIgnoreUntil" . }}</summary><div>
+
+<!-- Whitespace above and below is required so `.Reason` is rendered as Markdown, not as plain text within HTML. -->
+{{ .Reason }}
+
+</div></details>{{ else }}{{ template "findingIgnoreUntil" . }}{{ end }}{{ end }}
 {{ define "cvssScore" }}{{ .Score.StringFixed 1 | nbsp}}{{ end }}
 {{ define "cvssVector" }}{{ if .Vector }}<a href="{{ .VectorURL }}">{{ .Vector }}</a>{{ else }}&nbsp;{{end}}{{ end }}
 {{ define "cvssCells" }}

--- a/src/report/testdata/TestReports/some_findings_ignored.golden
+++ b/src/report/testdata/TestReports/some_findings_ignored.golden
@@ -98,7 +98,12 @@
 <tr>
 <td><details><summary><a href="http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-5300">CVE-2019-5300</a></summary><div>Another vulnerability.</div></details></td>
 <td>Critical</td>
-<td><details><summary>2023-12-31</summary><div>Ignored to give the base image a chance to be updated</div></details></td>
+<td><details><summary>2023-12-31</summary><div>
+
+
+Ignored to give the base image a chance to be updated
+
+</div></details></td>
 <td>5300-package 5300-version</td>
 
 <td>9.0</td><td><a href="https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV%3AN%2FAC%3AL%2FPR%3AN%2FUI%3AN%2FS%3AU%2FC%3AH%2FI%3AH%2FA%3AN&amp;version=3.1">AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N</a></td>


### PR DESCRIPTION
The finding ignore "reason" field was rendered on a single line inside HTML tags, so the Buildkite Markdown processor didn't process it as Markdown.

Leaving blank lines around it allows the Markdown processor to pick it up and all is then tickety-boo.
