### PR TITLE
fix: small QOL changes

### DIFF
--- a/docs/ignore-findings.md
+++ b/docs/ignore-findings.md
@@ -1,6 +1,36 @@
 # Ignoring findings
 
-Findings can be ignored using a YAML file with the following structure:
+Findings can be ignored using a YAML configuration file.
+
+> [!IMPORTANT]
+> When a finding is ignored, it is removed from consideration for threshold
+> checks but it's not discarded. The report created by the plugin adds details
+> to the results, giving high visibility on the configured behaviour.
+>
+> See examples [below](#rendering).
+
+## File naming
+
+### Repository level
+
+Create a file **in the repository** with one of the following names:
+
+- `.ecr-scan-results-ignore.y[a]ml`
+- `.buildkite/ecr-scan-results-ignore.y[a]ml`
+- `buildkite/ecr-scan-results-ignore.y[a]ml`
+
+Files are load in this order: definitions loaded first take precedence.
+
+### Agent level
+
+A configuration file **on the agent itself** in the
+`/etc/ecr-scan-results-buildkite-plugin` directory allows for organizations to
+ship agents with plugin configuration that centrally manages findings that can
+be ignored.
+
+_Agent configuration takes precedence over repository configuration._
+
+## File format
 
 ```yaml
 ignores:
@@ -12,23 +42,24 @@ ignores:
   - id: CVE-2023-300
 ```
 
-- each element must have at least the `id` field
-- the `until` field defines the expiry of this ignore entry. This allows a team time to respond while temporarily allowing builds to continue.
-- the `reason` field gives a justification that is rendered in the annotation for greater visibility. Including the "why" in this field is highly recommended.
+- each element must have at least the `id` field: this is effectively the
+  primary key and is used to match duplicates.
+- the `until` field defines the expiry of this ignore entry. This allows a team
+  time to respond while temporarily allowing builds to continue.
+- the `reason` field gives a justification that is rendered in the annotation
+  for greater visibility. Including the "why" in this field is highly
+  recommended.
 
-Ignore configuration can be specified in a number of places. If a listing for a finding with the same CVE name appears in multiple files, the most local wins: central configuration can be overridden by the repository.
-
-From least to most important:
-
-- `/etc/ecr-scan-results-buildkite-plugin/ignore.y[a]ml` (part of the agent, not modifiable by builds)
-- `buildkite/ecr-scan-results-ignore.y[a]ml` (specified alongside the pipeline)
-- `.buildkite/ecr-scan-results-ignore.y[a]ml`
-- `.ecr-scan-results-ignore.y[a]ml` (local repository configuration)
-
-Configuration in the `/etc/ecr-scan-results-buildkite-plugin` directory allows for organizations to ship agents with plugin configuration that centrally manages findings that can be ignored.
-
-> [!IMPORTANT]
-> When a finding is ignored, it is removed from consideration for threshold checks, but it's not discarded. The annotation created by the plugin adds details to the results, giving high visibility on the configured behaviour.
+> [!NOTE]
+> So:
+>
+> - agent configuration is more important than repository configuration
+> - multiple repository configuration files are overlaid in priority order
+> - expired entries are eliminated early and do not override anything
+> - entries are matched by `id` only
+>
+> Unsure if the configuration is taking effect? Check the plugin output.
+> Active ignore definitions are listed at the start of the plugin's execution.
 
 ## Rendering
 

--- a/src/buildkite/agent.go
+++ b/src/buildkite/agent.go
@@ -25,6 +25,11 @@ func (a Agent) ArtifactUpload(ctx context.Context, path string) error {
 func execCmd(ctx context.Context, executableName string, stdin *string, args ...string) error {
 	Logf("Executing: %s %s\n", executableName, strings.Join(args, " "))
 
+	// allow disabling the agent for local development purposes
+	if os.Getenv("ECRSCANRESULTS_DISABLE_AGENT") == "true" {
+		return nil
+	}
+
 	cmd := osexec.CommandContext(ctx, executableName, args...)
 
 	if stdin != nil {

--- a/src/findingconfig/until_test.go
+++ b/src/findingconfig/until_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/cultureamp/ecrscanresults/findingconfig"
+	_ "github.com/hexops/autogold/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"

--- a/src/registry/ecr.go
+++ b/src/registry/ecr.go
@@ -105,6 +105,7 @@ func (r *RegistryScan) WaitForScanFindings(ctx context.Context, digestInfo Regis
 		ImageId: &types.ImageIdentifier{
 			ImageDigest: &digestInfo.Tag,
 		},
+		MaxResults: aws.Int32(1), // reduce the size of the return payload when waiting for the completion state
 	}, maxTotalDelay, func(opts *ecr.ImageScanCompleteWaiterOptions) {
 		opts.LogWaitAttempts = true
 		opts.MinDelay = minAttemptDelay

--- a/src/runtimeerrors/error_test.go
+++ b/src/runtimeerrors/error_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/cultureamp/ecrscanresults/runtimeerrors"
+	_ "github.com/hexops/autogold/v2"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
This PR has 4 small changes:

1. ensuring that `autogold` is imported in packages where it's not used, so the `-update` flag doesn't cause spurious errors.
2. all agent calls to be disabled in dev via an environment variable `ECRSCANRESULTS_DISABLE_AGENT`
3. Restrict the number of results returned by the scan results waiter: these are discarded, so there's a small efficiency gain here.
4. documentation updates that hopefully clarify a couple of points of confusion.