### PR TITLE
ci: update to latest versions of actions in use

### DIFF
--- a/.github/workflows/bash-checks.yaml
+++ b/.github/workflows/bash-checks.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Lint
         run: docker-compose run --rm lint

--- a/.github/workflows/go-checks.yml
+++ b/.github/workflows/go-checks.yml
@@ -11,12 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version-file: src/go.mod
-          cache: true
           cache-dependency-path: src/go.sum
 
       - name: Check Go Modules
@@ -26,9 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version-file: src/go.mod
 
@@ -43,12 +42,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version-file: src/go.mod
-          cache: true
           cache-dependency-path: src/go.sum
 
       - name: Test code

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,14 +10,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version-file: src/go.mod
-          cache: true
           cache-dependency-path: src/go.sum
 
       - name: Run tests
@@ -25,7 +24,7 @@ jobs:
         working-directory: src
 
       - name: Release Binaries
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@v5
         with:
           distribution: goreleaser
           version: latest


### PR DESCRIPTION
Upgrade to actions that use Node 20 instead of the now-deprecated Node 16.