### PR TITLE
feat: Option to fail the build when scan results cannot be downloaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,18 @@ When supplied, this is used to title the report annotation in place of the
 repository name and tag. Useful sometimes when the repo name and tag make the
 reports harder to scan visually.
 
+### `fail-build-on-plugin-failure` (Optional, boolean. Default: false)
+
+By default, a failure to fetch the results of an image scan will not cause the
+build to fail, since scan access and availability can be flakey. The build will
+fail only if the plugin finds results and the results exceed `max-criticals` or
+`max-highs`.
+
+When set to `true`, the build will fail if the plugin fails to fetch scan
+results. This may results in builds failing even if the images have no
+vulnerabilities at all. Useful if you prefer to pass only with a confirmed good
+result.
+
 ## Requirements
 
 ### ECR Basic scanning only

--- a/README.md
+++ b/README.md
@@ -7,15 +7,19 @@ configuration file][ignore-findings], and there are configurable thresholds on
 absolute numbers of allowed critical and high vulnerabilities.
 
 > [!WARNING]
-> This plugin will only fail the build if the thresholds are exceeded. Failing
-> to read configuration or to download scan results are not considered blocking
-> failures.
+> By default, this plugin will only fail the build if the thresholds are
+> exceeded. Failing to read configuration or to download scan results are only
+> considered blocking failures if `fail-build-on-plugin-failure` is explicitly
+> set to `true`.
 >
-> When configuring the plugin, check the plugin output to ensure that scan
-> results are being downloaded as expected.
+> When configuring the plugin, you can either:
+> - Check the plugin output to ensure that scan results are being downloaded as
+>   expected, or
+> - Set `fail-build-on-plugin-failure` to `true` to raise the visibility of
+>   problems with fetching scan results.
 >
-> If blocking on configuration or retrieval failures is desired for use case,
-> consider submitting a PR to allow this to be configured.
+> If blocking on configuration or retrieval failures is desired for your use
+> case, see the `fail-build-on-plugin-failure` configuration item below.
 
 ## Rendering
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -17,4 +17,6 @@ configuration:
       type: string
     image-label:
       type: string
+    fail-build-on-plugin-failure:
+      type: boolean
   additionalProperties: false


### PR DESCRIPTION
This change adds a boolean configuration item `fail-build-on-plugin-failure`. It allows users to treat all errors in the plugin as build failures, as suggested in the [README](https://github.com/cultureamp/ecr-scan-results-buildkite-plugin/blob/00cf2999273c9351c98e093ca01ae7e36d80432c/README.md).

`fail-build-on-plugin-failure` is `false` by default, preserving current behaviour.

When `fail-build-on-plugin-failure` is set to `true`, any error returned from `runCommand` will be treated as fatal.

**Note:** Since the load-bearing part of this change is in `main.go`, I was not quite sure how you would prefer to have it tested. I'd love some feedback on that in particular :)