### PR TITLE
fix: retry when scan is not initially present

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.25.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.33.16 // indirect
-	github.com/aws/smithy-go v1.22.2 // indirect
+	github.com/aws/smithy-go v1.22.2
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20240206212017-5795caca6e8e
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/go-containerregistry v0.20.3

--- a/src/registry/ecr.go
+++ b/src/registry/ecr.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"time"
@@ -9,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
 	"github.com/aws/aws-sdk-go-v2/service/ecr/types"
+	"github.com/aws/smithy-go"
 )
 
 var registryImageExpr = regexp.MustCompile(`^(?P<registryId>[^.]+)\.dkr\.ecr\.(?P<region>[^.]+).amazonaws.com/(?P<repoName>[^:@]+)(?::(?P<tag>.+))?(?:@(?P<digest>.+))?$`)
@@ -137,7 +139,7 @@ func (r *RegistryScan) GetLabelDigest(ctx context.Context, imageInfo ImageRefere
 }
 
 func (r *RegistryScan) WaitForScanFindings(ctx context.Context, digestInfo ImageReference) error {
-	waiter := ecr.NewImageScanCompleteWaiter(r.Client)
+	waiter := ecr.NewImageScanCompleteWaiter(r.Client, optionsScanFindingsRetryPolicy)
 
 	// wait between attempts for between 3 and 15 secs (exponential backoff)
 	// wait for a maximum of 3 minutes
@@ -204,4 +206,26 @@ func (r *RegistryScan) GetScanFindings(ctx context.Context, digestInfo ImageRefe
 	}
 
 	return out, nil
+}
+
+type RetryPolicyFunc = func(context.Context, *ecr.DescribeImageScanFindingsInput, *ecr.DescribeImageScanFindingsOutput, error) (bool, error)
+
+func optionsScanFindingsRetryPolicy(opts *ecr.ImageScanCompleteWaiterOptions) {
+	defaultRetryable := opts.Retryable
+	opts.Retryable = scanStateRetryableOnNotFound(defaultRetryable)
+}
+
+func scanStateRetryableOnNotFound(wrapped RetryPolicyFunc) RetryPolicyFunc {
+	return func(ctx context.Context, input *ecr.DescribeImageScanFindingsInput, output *ecr.DescribeImageScanFindingsOutput, err error) (bool, error) {
+		var aerr smithy.APIError
+		if err != nil && errors.As(err, &aerr) {
+			fmt.Printf("Smithy error?\n%+v\n%+v\n", aerr.ErrorCode(), aerr.ErrorFault())
+			if aerr.ErrorCode() == "ScanNotFoundException" {
+				fmt.Println("retrying")
+				return true, nil
+			}
+		}
+
+		return wrapped(ctx, input, output, err)
+	}
 }


### PR DESCRIPTION
The plugin fails when attempting to retrieve a report if the scan result (in pending status) has not already been created by ECR. This happens more regularly in recent versions as the plugin appears to execute a little faster before ECR gets going.

By allowing retry on `ScanNotFound`, the waiter process will continue to request results until they are finished or the retry period is exhausted. For accounts with ECR configured to scan images this will work just fine.

There is an edge case where the plugin will now need to time out waiting for a scan when automatic scanning is not enabled in the AWS account. It will still fail, just take longer. This is an acceptable trade-off.

Thanks to @madobrien for contributing some tests for this functionality!