### PR TITLE
fix: add retry logic to get over transient network issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ steps:
   - command: "command which creates an image"
     # the docker-compose plugin may be used here instead of a command
     plugins:
-      - cultureamp/ecr-scan-results#v1.6.0:
+      - cultureamp/ecr-scan-results#v1.6.6:
           image-name: "$BUILD_REPO:deploy-$BUILD_TAG"
 ```
 
@@ -77,7 +77,7 @@ steps:
     plugins:
       - cultureamp/aws-assume-role:
           role: ${BUILD_ROLE}
-      - cultureamp/ecr-scan-results#v1.6.0:
+      - cultureamp/ecr-scan-results#v1.6.6:
           image-name: "$BUILD_REPO:deploy-$BUILD_TAG"
 ```
 
@@ -110,7 +110,7 @@ steps:
     plugins:
       - cultureamp/aws-assume-role:
           role: ${BUILD_ROLE}
-      - cultureamp/ecr-scan-results#v1.6.0:
+      - cultureamp/ecr-scan-results#v1.6.6:
           image-name: "$BUILD_REPO:deploy-$BUILD_TAG"
           max-criticals: "1"
           max-highs: "10"

--- a/lib/download.bash
+++ b/lib/download.bash
@@ -49,17 +49,16 @@ retry_download(){
   for (( i=1 ; i<=max_retries ; i++ ))
   do
      if [ "$3" = "curl" ]; then
-        curl -sSfL "$1" -o "$2" && return 0
+        curl --silent --show-error --fail --location  "$1" -o "$2" && return 0
      elif [ "$3" = "wget" ]; then
         wget "$1" -O "$2" && return 0
      fi
 
-     echo "Attempt $i failed. Retrying"
+     echo "Attempt $i failed. Retrying" >&2
      sleep $retry_delay 
   done
 
-  echo "Download failed after $max_retries attempts"
-  return 1
+  err "Download failed after $max_retries attempts" >&2
 }
 
 # This wraps curl or wget.

--- a/lib/download.bash
+++ b/lib/download.bash
@@ -49,9 +49,9 @@ retry_download(){
   for (( i=1 ; i<=max_retries ; i++ ))
   do
      if [ "$3" = "curl" ]; then
-        curl -sSfL "$1" -o "$2"  && echo "Success" && return 0
+        curl -sSfL "$1" -o "$2" && return 0
      elif [ "$3" = "wget" ]; then
-        wget "$1" -O "$2" && echo "Success" && return 0
+        wget "$1" -O "$2" && return 0
      fi
 
      echo "Attempt $i failed. Retrying"

--- a/lib/download.bash
+++ b/lib/download.bash
@@ -46,12 +46,12 @@ retry_download(){
   local max_retries=5
   local retry_delay=2
 
-  for (( i=0 ; i<max_retries ; i++ ))
+  for (( i=1 ; i<=max_retries ; i++ ))
   do
      if [ "$3" = "curl" ]; then
-        curl -sSfL "$1" -o "$2" && return 0
+        curl -sSfL "$1" -o "$2"  && echo "Success" && return 0
      elif [ "$3" = "wget" ]; then
-        wget "$1" -O "$2" && return 0
+        wget "$1" -O "$2" && echo "Success" && return 0
      fi
 
      echo "Attempt $i failed. Retrying"

--- a/lib/download.bash
+++ b/lib/download.bash
@@ -41,7 +41,7 @@ need_cmd() {
   fi
 }
 
-# This function retires the download - if it fails due to network issues.
+# This function retries the download - if it fails due to network issues.
 retry_download(){
   local max_retries=5
   local retry_delay=2
@@ -51,7 +51,7 @@ retry_download(){
      if [ "$3" = "curl" ]; then
         curl -sSfL "$1" -o "$2" && return 0
      elif [ "$3" = "wget" ]; then
-        wget "$1" -O "$2"
+        wget "$1" -O "$2" && return 0
      fi
 
      echo "Attempt $i failed. Retrying"
@@ -60,7 +60,6 @@ retry_download(){
 
   echo "Download failed after $max_retries attempts"
   return 1
-
 }
 
 # This wraps curl or wget.

--- a/tests/download.bats
+++ b/tests/download.bats
@@ -4,7 +4,6 @@ load "${BATS_PLUGIN_PATH}/load.bash"
 
 load '../lib/download.bash'
 
-is_stubbed=false
 sleep_stub_command='echo sleep $@'
 sleep_stubs=("$sleep_stub_command" "$sleep_stub_command" "$sleep_stub_command" "$sleep_stub_command" "$sleep_stub_command")
 
@@ -23,12 +22,9 @@ setup() {
 
 teardown() {
     unset BUILDKITE_PLUGIN_ECR_SCAN_RESULTS_BUILDKITE_PLUGIN_TEST_MODE
-    if $is_stubbed; then
-      unstub curl || true
-      unstub sleep || true
-    else
-     rm ./ecr-scan-results-buildkite-plugin || true
-    fi
+    unstub curl || true
+    unstub sleep || true
+    rm ./ecr-scan-results-buildkite-plugin || true
 }
 
 create_script() {
@@ -77,7 +73,6 @@ EOM
   assert_line --partial "Attempt 1"
   assert_line --partial "Attempt 2"
   assert_line --partial "Success"
-
 }
 
 @test "Attempts to download and fails after maximum tries" {
@@ -90,7 +85,6 @@ EOM
         "echo 'curl 3 (7) Failed to connect to example.com port 80 - Connection refused' && exit 7"  \
         "echo 'curl 4 (7) Failed to connect to example.com port 80 - Connection refused' && exit 7"  \
         "echo 'curl 5 (7) Failed to connect to example.com port 80 - Connection refused' && exit 7"  \
-        "echo 'curl 6 (7) Failed to connect to example.com port 80 - Connection refused' && exit 7"  \
 
   stub sleep "${sleep_stubs[@]}"
   is_stubbed=true
@@ -98,7 +92,7 @@ EOM
   # executes the retry download command
   run retry_download "https://example.com" "$TMPDIR/output-plugin" "curl"
 
-  assert_failure 1
-  #Checks if multiple attempts are made to retry the download
+  assert_failure
+  # Checks if multiple attempts are made to retry the download
   assert_line --partial "Download failed after 5 attempts" 
 }

--- a/tests/download.bats
+++ b/tests/download.bats
@@ -4,13 +4,18 @@ load "${BATS_PLUGIN_PATH}/load.bash"
 
 load '../lib/download.bash'
 
+is_stubbed=false
+sleep_stub_command='echo sleep $@'
+sleep_stubs=("$sleep_stub_command" "$sleep_stub_command" "$sleep_stub_command" "$sleep_stub_command" "$sleep_stub_command")
+
+
 #
 # Tests for top-level docker bootstrap command. The rest of the plugin runs in Go.
 #
 
 # Uncomment the following line to debug stub failures
 # export [stub_command]_STUB_DEBUG=/dev/tty
-#export DOCKER_STUB_DEBUG=/dev/tty
+#export SLEEP_STUB_DEBUG=/dev/tty
 
 setup() {
   export BUILDKITE_PLUGIN_ECR_SCAN_RESULTS_BUILDKITE_PLUGIN_TEST_MODE=true
@@ -18,7 +23,12 @@ setup() {
 
 teardown() {
     unset BUILDKITE_PLUGIN_ECR_SCAN_RESULTS_BUILDKITE_PLUGIN_TEST_MODE
-    rm ./ecr-scan-results-buildkite-plugin || true
+    if $is_stubbed; then
+      unstub curl || true
+      unstub sleep || true
+    else
+     rm ./ecr-scan-results-buildkite-plugin || true
+    fi
 }
 
 create_script() {
@@ -45,4 +55,50 @@ EOM
   assert_success
   assert_line --regexp "https://github.com/cultureamp/ecr-scan-results-buildkite-plugin/releases/latest/download/ecr-scan-results-buildkite-plugin_linux_amd64 ecr-scan-results-buildkite-plugin"
   assert_line --regexp "executing ecr-scan-results-buildkite-plugin"
+}
+
+@test "Attempts to download and succeed after 2 tries" {
+
+  # Fails for first 2 tries and passes on later 
+
+  stub curl \
+      "echo 'curl 1 - Could not resolve host' && exit 6" \
+      "echo 'curl 2 - Failed to connect to example.com port 80 - Connection refused' && exit 7" \
+      "echo 'curl 3 - Success' && exit 0"
+
+  stub sleep "${sleep_stubs[@]}"
+  is_stubbed=true
+
+  # executes the retry download command
+  run retry_download "https://example.com" "$TMPDIR/output-plugin" "curl"
+
+  
+  assert_success
+  assert_line --partial "Attempt 1"
+  assert_line --partial "Attempt 2"
+  assert_line --partial "Success"
+
+}
+
+@test "Attempts to download and fails after maximum tries" {
+
+  # Fails for all 5 (maximum) tries 
+
+  stub curl \
+        "echo 'curl 1 - Could not resolve host: example.com' && exit 6" \
+        "echo 'curl 2 (7) Failed to connect to example.com port 80 - Connection refused' && exit 7" \
+        "echo 'curl 3 (7) Failed to connect to example.com port 80 - Connection refused' && exit 7"  \
+        "echo 'curl 4 (7) Failed to connect to example.com port 80 - Connection refused' && exit 7"  \
+        "echo 'curl 5 (7) Failed to connect to example.com port 80 - Connection refused' && exit 7"  \
+        "echo 'curl 6 (7) Failed to connect to example.com port 80 - Connection refused' && exit 7"  \
+
+  stub sleep "${sleep_stubs[@]}"
+  is_stubbed=true
+
+  # executes the retry download command
+  run retry_download "https://example.com" "$TMPDIR/output-plugin" "curl"
+
+  assert_failure 1
+  #Checks if multiple attempts are made to retry the download
+  assert_line --partial "Download failed after 5 attempts" 
 }


### PR DESCRIPTION
# Purpose 🎯 
This adds a retry logic to the downloader functionality, to get over temporary transient network issues
- Function attempts a maximum of 5 retries
-  Delay of two seconds between each attempt
- Tests
   - Adds two tests to verify the above mentioned functionality

# Context 🧠 

- [CSRE-5411](https://cultureamp.atlassian.net/browse/CSRE-5411)

[CSRE-5411]: https://cultureamp.atlassian.net/browse/CSRE-5411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ