### PR TITLE
ci: tune settings for, and address golangci linting violations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,6 +41,7 @@ linters:
     - paralleltest
     - prealloc
     - revive
+    - tenv
     - tagalign
     - tagliatelle
     - testpackage

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,7 +23,6 @@ linters:
     - err113
     - errname
     - exhaustruct
-    - exportloopref
     - forbidigo
     - funlen
     - gci
@@ -33,7 +32,6 @@ linters:
     - godot
     - godox
     - gofumpt
-    - gomnd
     - lll
     - mnd
     - musttag

--- a/src/registry/ecr_test.go
+++ b/src/registry/ecr_test.go
@@ -96,7 +96,7 @@ func TestScanStateRetryableOnNotFound(t *testing.T) {
 			Message: "Scan not found",
 		}
 
-		shouldRetry, err := retry(context.Background(), nil, nil, scanNotFoundErr)
+		shouldRetry, err := retry(t.Context(), nil, nil, scanNotFoundErr)
 
 		assert.True(t, shouldRetry, "Should retry on ScanNotFoundException")
 		require.NoError(t, err, "Should not return an error")
@@ -111,7 +111,7 @@ func TestScanStateRetryableOnNotFound(t *testing.T) {
 			Message: "Some other error",
 		}
 
-		shouldRetry, err := retry(context.Background(), nil, nil, otherErr)
+		shouldRetry, err := retry(t.Context(), nil, nil, otherErr)
 
 		assert.True(t, shouldRetry, "Should return wrapped function's retry decision")
 		require.EqualError(t, err, "wrapped error", "Should return wrapped function's error")
@@ -123,7 +123,7 @@ func TestScanStateRetryableOnNotFound(t *testing.T) {
 
 		nonAPIErr := errors.New("non-API error")
 
-		shouldRetry, err := retry(context.Background(), nil, nil, nonAPIErr)
+		shouldRetry, err := retry(t.Context(), nil, nil, nonAPIErr)
 
 		assert.False(t, shouldRetry, "Should return wrapped function's retry decision")
 		require.NoError(t, err, "Should return wrapped function's error")


### PR DESCRIPTION
# Purpose 🎯 

At some point in #111, a linting violation was raised where `usetesting` flagged how context is spawned within tests, causing Github Actions workflows to return an error.

These changes update the config for `golangci` to remove deprecated linters, and address the linting violation.

# Context 🧠 

Identified during our regular health cycle.