### PR TITLE
feat: exit with a specific exit code if the scan times out

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -18,4 +18,4 @@ fi
 # shellcheck source=lib/download.bash
 . "$dir/../lib/download.bash"
 
-download_binary_and_run "$@" || exit 1
+download_binary_and_run "$@"

--- a/lib/download.bash
+++ b/lib/download.bash
@@ -112,4 +112,5 @@ download_binary_and_run() {
   chmod +x ${_executable}
 
   ./${_executable}
+  return $?
 }

--- a/src/main.go
+++ b/src/main.go
@@ -61,6 +61,10 @@ func main() {
 		// can be quite flakey. For this reason, we wrap most issues in a
 		// non-fatal error type.
 		if pluginConfig.FailBuildOnPluginFailure || runtimeerrors.IsFatal(err) {
+			// If timeout error, exit 75 (POSIX timer expired)
+			if registry.IsErrWaiterTimeout(err) {
+				os.Exit(75)
+			}
 			os.Exit(1)
 		} else {
 			// Attempt to annotate the build with the issue, but it's OK if the

--- a/src/registry/ecr.go
+++ b/src/registry/ecr.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -138,6 +140,18 @@ func (r *RegistryScan) GetLabelDigest(ctx context.Context, imageInfo ImageRefere
 	return digestInfo, nil
 }
 
+type WaiterError string
+
+func (w WaiterError) Error() string {
+	return string(w)
+}
+
+func IsErrWaiterTimeout(w error) bool {
+	return errors.Is(w, ErrWaiterTimeout)
+}
+
+var ErrWaiterTimeout WaiterError = "image scan waiter timed out"
+
 func (r *RegistryScan) WaitForScanFindings(ctx context.Context, digestInfo ImageReference) error {
 	waiter := ecr.NewImageScanCompleteWaiter(r.Client, optionsScanFindingsRetryPolicy)
 
@@ -147,18 +161,45 @@ func (r *RegistryScan) WaitForScanFindings(ctx context.Context, digestInfo Image
 	maxAttemptDelay := 15 * time.Second
 	maxTotalDelay := 3 * time.Minute
 
-	err := waiter.Wait(ctx, &ecr.DescribeImageScanFindingsInput{
-		RegistryId:     &digestInfo.RegistryID,
-		RepositoryName: &digestInfo.Name,
-		ImageId: &types.ImageIdentifier{
-			ImageDigest: &digestInfo.Digest,
+	err := waiter.Wait(ctx,
+		&ecr.DescribeImageScanFindingsInput{
+			RegistryId:     &digestInfo.RegistryID,
+			RepositoryName: &digestInfo.Name,
+			ImageId: &types.ImageIdentifier{
+				ImageDigest: &digestInfo.Digest,
+			},
+			MaxResults: aws.Int32(1), // reduce the size of the return payload when waiting for the completion state
 		},
-		MaxResults: aws.Int32(1), // reduce the size of the return payload when waiting for the completion state
-	}, maxTotalDelay, func(opts *ecr.ImageScanCompleteWaiterOptions) {
-		opts.LogWaitAttempts = true
-		opts.MinDelay = minAttemptDelay
-		opts.MaxDelay = maxAttemptDelay
-	})
+		maxTotalDelay,
+		func(opts *ecr.ImageScanCompleteWaiterOptions) {
+			opts.LogWaitAttempts = true
+			opts.MinDelay = minAttemptDelay
+			opts.MaxDelay = maxAttemptDelay
+		},
+		func(opts *ecr.ImageScanCompleteWaiterOptions) {
+			/*
+				We must copy this function outside the closure to avoid an infinite loop
+				If we copy it inside the closure the compiler will assign it to a pointer
+				to itself
+			*/
+			defaultRetryableFunc := opts.Retryable
+			customRetryable := func(ctx context.Context, params *ecr.DescribeImageScanFindingsInput,
+				output *ecr.DescribeImageScanFindingsOutput, err error) (bool, error) {
+
+				if err != nil && strings.Contains(err.Error(), "AccessDeniedException") {
+					return false, err
+				}
+				if err != nil {
+					log.Printf("error waiting for scan findings: %v", err)
+				}
+				return defaultRetryableFunc(ctx, params, output, err)
+			}
+			opts.Retryable = customRetryable
+		})
+
+	if err != nil && err.Error() == "exceeded max wait time for ImageScanComplete waiter" {
+		return ErrWaiterTimeout
+	}
 
 	// It is not good style to compare the error string, but this is the only way
 	// to capture that the scan failed, but everything else is hunky dory. We

--- a/src/registry/ecr_test.go
+++ b/src/registry/ecr_test.go
@@ -73,23 +73,23 @@ func TestRegistryInfoFromURLFails(t *testing.T) {
 	assert.Equal(t, ImageReference{}, info)
 }
 
-func TestScanStateRetryableOnNotFound(t *testing.T) {
-	setupRetryTest := func(wrappedReturnValue bool, wrappedError error) (func(*testing.T, bool), RetryPolicyFunc) {
-		wrappedCalled := false
-		wrapped := func(ctx context.Context, input *ecr.DescribeImageScanFindingsInput, output *ecr.DescribeImageScanFindingsOutput, err error) (bool, error) {
-			wrappedCalled = true
-			return wrappedReturnValue, wrappedError
-		}
-
-		retry := scanStateRetryableOnNotFound(wrapped)
-		return func(t *testing.T, expected bool) {
-			t.Helper()
-			assert.Equal(t, expected, wrappedCalled, "Calling wrapped function: expected %t but was %t", expected, wrappedCalled)
-		}, retry
+func setupRetryTest(wrappedReturnValue bool, wrappedError error, retryPolicyFunc func(wrapped RetryPolicyFunc) RetryPolicyFunc) (func(*testing.T, bool), RetryPolicyFunc) {
+	wrappedCalled := false
+	wrapped := func(ctx context.Context, input *ecr.DescribeImageScanFindingsInput, output *ecr.DescribeImageScanFindingsOutput, err error) (bool, error) {
+		wrappedCalled = true
+		return wrappedReturnValue, wrappedError
 	}
 
+	retry := retryPolicyFunc(wrapped)
+	return func(t *testing.T, expected bool) {
+		t.Helper()
+		assert.Equal(t, expected, wrappedCalled, "Calling wrapped function: expected %t but was %t", expected, wrappedCalled)
+	}, retry
+}
+
+func TestScanStateRetryableOnNotFound(t *testing.T) {
 	t.Run("Returns true for ScanNotFoundException", func(t *testing.T) {
-		assertCalled, retry := setupRetryTest(false, nil)
+		assertCalled, retry := setupRetryTest(false, nil, scanStateRetryableOnNotFound)
 
 		scanNotFoundErr := &smithy.GenericAPIError{
 			Code:    "ScanNotFoundException",
@@ -104,7 +104,7 @@ func TestScanStateRetryableOnNotFound(t *testing.T) {
 	})
 
 	t.Run("Delegates to wrapped function for other API errors", func(t *testing.T) {
-		assertWrapped, retry := setupRetryTest(true, errors.New("wrapped error"))
+		assertWrapped, retry := setupRetryTest(true, errors.New("wrapped error"), scanStateRetryableOnNotFound)
 
 		otherErr := &smithy.GenericAPIError{
 			Code:    "OtherError",
@@ -119,7 +119,48 @@ func TestScanStateRetryableOnNotFound(t *testing.T) {
 	})
 
 	t.Run("Delegates to wrapped function for non-API errors", func(t *testing.T) {
-		assertWrapped, retry := setupRetryTest(false, nil)
+		assertWrapped, retry := setupRetryTest(false, nil, scanStateRetryableOnNotFound)
+
+		nonAPIErr := errors.New("non-API error")
+
+		shouldRetry, err := retry(t.Context(), nil, nil, nonAPIErr)
+
+		assert.False(t, shouldRetry, "Should return wrapped function's retry decision")
+		require.NoError(t, err, "Should return wrapped function's error")
+		assertWrapped(t, true)
+	})
+}
+
+func TestWaiterStateRetryable(t *testing.T) {
+	t.Run("Returns false for AccessDeniedException", func(t *testing.T) {
+		assertCalled, retry := setupRetryTest(false, nil, waiterStateRetryable)
+
+		accessDeniedErr := errors.New("AccessDeniedException")
+
+		shouldRetry, err := retry(t.Context(), nil, nil, accessDeniedErr)
+
+		assert.False(t, shouldRetry, "Should not retry on AccessDeniedException")
+		require.EqualError(t, err, "AccessDeniedException", "Should return the AccessDeniedException error")
+		assertCalled(t, false)
+	})
+
+	t.Run("Delegates to wrapped function for other API errors", func(t *testing.T) {
+		assertWrapped, retry := setupRetryTest(true, errors.New("wrapped error"), waiterStateRetryable)
+
+		otherErr := &smithy.GenericAPIError{
+			Code:    "OtherError",
+			Message: "Some other error",
+		}
+
+		shouldRetry, err := retry(t.Context(), nil, nil, otherErr)
+
+		assert.True(t, shouldRetry, "Should return wrapped function's retry decision")
+		require.EqualError(t, err, "wrapped error", "Should return wrapped function's error")
+		assertWrapped(t, true)
+	})
+
+	t.Run("Delegates to wrapped function for non-API errors", func(t *testing.T) {
+		assertWrapped, retry := setupRetryTest(false, nil, waiterStateRetryable)
 
 		nonAPIErr := errors.New("non-API error")
 


### PR DESCRIPTION
Occasionally the scan results will take longer than the timeout period to complete. This is not necessarily a result that should block a pipeline, since the scan results are unknown, and may be ok on retry.

In this case, it would be useful to be able to retry or soft_fail the buildkite step. To this end, an explicit exit code for timeouts is added, offering users of the plugin to decide how their pipelines should respond in such an event.