### PR TITLE
feat: fix fail-build-on-plugin-failure, add max-wait-time option

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,16 @@ results. This may results in builds failing even if the images have no
 vulnerabilities at all. Useful if you prefer to pass only with a confirmed good
 result.
 
+### `max-wait-time` (Optional, duration string. Default: "3m")
+
+The maximum time to wait for the ECR scan to complete before giving up. Accepts
+a [Go duration string](https://pkg.go.dev/time#ParseDuration) like `"5m"` or
+`"90s"`.
+
+The default of 3 minutes is enough for most repositories, but ECR basic
+scanning can take longer on some registries. If the plugin regularly times out
+waiting for results (`image scan waiter timed out`), increase this value.
+
 ## Requirements
 
 ### ECR Basic scanning only

--- a/plugin.yml
+++ b/plugin.yml
@@ -19,4 +19,6 @@ configuration:
       type: string
     fail-build-on-plugin-failure:
       type: boolean
+    max-wait-time:
+      type: string
   additionalProperties: false

--- a/src/main.go
+++ b/src/main.go
@@ -29,7 +29,7 @@ type Config struct {
 	ImageLabel                string `envconfig:"BUILDKITE_PLUGIN_ECR_SCAN_RESULTS_IMAGE_LABEL" split_words:"true"`
 	CriticalSeverityThreshold int32  `envconfig:"BUILDKITE_PLUGIN_ECR_SCAN_RESULTS_MAX_CRITICALS" split_words:"true"`
 	HighSeverityThreshold     int32  `envconfig:"BUILDKITE_PLUGIN_ECR_SCAN_RESULTS_MAX_HIGHS" split_words:"true"`
-	FailBuildOnPluginFailure  bool   `envconfig:"FAIL_BUILD_ON_PLUGIN_FAILURE" default:"false"`
+	FailBuildOnPluginFailure  bool   `envconfig:"BUILDKITE_PLUGIN_ECR_SCAN_RESULTS_FAIL_BUILD_ON_PLUGIN_FAILURE" default:"false"`
 }
 
 func main() {

--- a/src/main.go
+++ b/src/main.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/cultureamp/ecrscanresults/buildkite"
@@ -23,13 +24,14 @@ import (
 )
 
 type Config struct {
-	AgentTestMode             bool   `envconfig:"ECR_SCAN_RESULTS_BUILDKITE_AGENT_TEST_MODE" split_words:"true"`
-	JobID                     string `envconfig:"BUILDKITE_JOB_ID" split_words:"true" required:"true"`
-	Repository                string `envconfig:"BUILDKITE_PLUGIN_ECR_SCAN_RESULTS_IMAGE_NAME" split_words:"true" required:"true"`
-	ImageLabel                string `envconfig:"BUILDKITE_PLUGIN_ECR_SCAN_RESULTS_IMAGE_LABEL" split_words:"true"`
-	CriticalSeverityThreshold int32  `envconfig:"BUILDKITE_PLUGIN_ECR_SCAN_RESULTS_MAX_CRITICALS" split_words:"true"`
-	HighSeverityThreshold     int32  `envconfig:"BUILDKITE_PLUGIN_ECR_SCAN_RESULTS_MAX_HIGHS" split_words:"true"`
-	FailBuildOnPluginFailure  bool   `envconfig:"BUILDKITE_PLUGIN_ECR_SCAN_RESULTS_FAIL_BUILD_ON_PLUGIN_FAILURE" default:"false"`
+	AgentTestMode             bool          `envconfig:"ECR_SCAN_RESULTS_BUILDKITE_AGENT_TEST_MODE" split_words:"true"`
+	JobID                     string        `envconfig:"BUILDKITE_JOB_ID" split_words:"true" required:"true"`
+	Repository                string        `envconfig:"BUILDKITE_PLUGIN_ECR_SCAN_RESULTS_IMAGE_NAME" split_words:"true" required:"true"`
+	ImageLabel                string        `envconfig:"BUILDKITE_PLUGIN_ECR_SCAN_RESULTS_IMAGE_LABEL" split_words:"true"`
+	CriticalSeverityThreshold int32         `envconfig:"BUILDKITE_PLUGIN_ECR_SCAN_RESULTS_MAX_CRITICALS" split_words:"true"`
+	HighSeverityThreshold     int32         `envconfig:"BUILDKITE_PLUGIN_ECR_SCAN_RESULTS_MAX_HIGHS" split_words:"true"`
+	FailBuildOnPluginFailure  bool          `envconfig:"BUILDKITE_PLUGIN_ECR_SCAN_RESULTS_FAIL_BUILD_ON_PLUGIN_FAILURE" default:"false"`
+	MaxWaitTime               time.Duration `envconfig:"BUILDKITE_PLUGIN_ECR_SCAN_RESULTS_MAX_WAIT_TIME" default:"3m"`
 }
 
 func main() {
@@ -46,6 +48,11 @@ func main() {
 
 	if pluginConfig.HighSeverityThreshold < 0 {
 		buildkite.LogFailuref("max-highs must be greater than or equal to 0")
+		os.Exit(1)
+	}
+
+	if pluginConfig.MaxWaitTime <= 0 {
+		buildkite.LogFailuref("max-wait-time must be a positive duration")
 		os.Exit(1)
 	}
 
@@ -151,7 +158,7 @@ func runCommand(ctx context.Context, pluginConfig Config, agent buildkite.Agent)
 	buildkite.Logf("Attempting to retrieve scan results for %d image(s)", len(imageDigests))
 
 	summaries, err := iter.MapErr(imageDigests, func(image *registry.PlatformImageReference) (finding.Summary, error) {
-		return getImageScanSummary(ctx, scan, *image, ignoreConfig)
+		return getImageScanSummary(ctx, scan, *image, ignoreConfig, pluginConfig.MaxWaitTime)
 	})
 	if err != nil {
 		return runtimeerrors.NonFatal("could not retrieve scan results", err)
@@ -231,8 +238,8 @@ func runCommand(ctx context.Context, pluginConfig Config, agent buildkite.Agent)
 // getImageScanSummary retrieves the scan results for the given image digest and
 // returns the initial summary for the image. This function may be called in
 // parallel for multiple images.
-func getImageScanSummary(ctx context.Context, scan *registry.RegistryScan, imageDigest registry.PlatformImageReference, ignoreConfig []findingconfig.Ignore) (finding.Summary, error) {
-	err := scan.WaitForScanFindings(ctx, imageDigest.ImageReference)
+func getImageScanSummary(ctx context.Context, scan *registry.RegistryScan, imageDigest registry.PlatformImageReference, ignoreConfig []findingconfig.Ignore, maxWaitTime time.Duration) (finding.Summary, error) {
+	err := scan.WaitForScanFindings(ctx, imageDigest.ImageReference, maxWaitTime)
 	if err != nil {
 		return finding.Summary{}, err
 	}

--- a/src/main_test.go
+++ b/src/main_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/kelseyhightower/envconfig"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigParsing(t *testing.T) {
+	t.Run("defaults", func(t *testing.T) {
+		setRequiredEnv(t)
+
+		var c Config
+		require.NoError(t, envconfig.Process("", &c))
+
+		assert.False(t, c.FailBuildOnPluginFailure)
+	})
+
+	t.Run("reads Buildkite-prefixed plugin configuration", func(t *testing.T) {
+		setRequiredEnv(t)
+		t.Setenv("BUILDKITE_PLUGIN_ECR_SCAN_RESULTS_FAIL_BUILD_ON_PLUGIN_FAILURE", "true")
+
+		var c Config
+		require.NoError(t, envconfig.Process("", &c))
+
+		assert.True(t, c.FailBuildOnPluginFailure)
+	})
+}
+
+func setRequiredEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("BUILDKITE_JOB_ID", "job-id")
+	t.Setenv("BUILDKITE_PLUGIN_ECR_SCAN_RESULTS_IMAGE_NAME", "123456789012.dkr.ecr.us-west-2.amazonaws.com/test-repo:latest")
+}

--- a/src/main_test.go
+++ b/src/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"testing"
+	"time"
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/stretchr/testify/assert"
@@ -16,16 +17,19 @@ func TestConfigParsing(t *testing.T) {
 		require.NoError(t, envconfig.Process("", &c))
 
 		assert.False(t, c.FailBuildOnPluginFailure)
+		assert.Equal(t, 3*time.Minute, c.MaxWaitTime)
 	})
 
 	t.Run("reads Buildkite-prefixed plugin configuration", func(t *testing.T) {
 		setRequiredEnv(t)
 		t.Setenv("BUILDKITE_PLUGIN_ECR_SCAN_RESULTS_FAIL_BUILD_ON_PLUGIN_FAILURE", "true")
+		t.Setenv("BUILDKITE_PLUGIN_ECR_SCAN_RESULTS_MAX_WAIT_TIME", "5m")
 
 		var c Config
 		require.NoError(t, envconfig.Process("", &c))
 
 		assert.True(t, c.FailBuildOnPluginFailure)
+		assert.Equal(t, 5*time.Minute, c.MaxWaitTime)
 	})
 }
 

--- a/src/registry/ecr.go
+++ b/src/registry/ecr.go
@@ -170,17 +170,16 @@ func IsErrWaiterTimeout(w error) bool {
 const ErrWaiterTimeout WaiterError = "image scan waiter timed out"
 
 // WaitForScanFindings blocks until the ECR image scan for digestInfo has
-// completed, or until the maximum wait time is exceeded.
-func (r *RegistryScan) WaitForScanFindings(ctx context.Context, digestInfo ImageReference) error {
+// completed, or until maxWaitTime is exceeded.
+func (r *RegistryScan) WaitForScanFindings(ctx context.Context, digestInfo ImageReference, maxWaitTime time.Duration) error {
 	waiter := ecr.NewImageScanCompleteWaiter(
 		r.Client,
 		withRetryPolicy(fastFailOnAccessDenied, retryOnScanNotFound),
 	)
 
-	// Poll every 3–15s with exponential backoff, up to 3 minutes total.
+	// Poll every 3–15s with exponential backoff, up to maxWaitTime total.
 	minAttemptDelay := 3 * time.Second
 	maxAttemptDelay := 15 * time.Second
-	maxTotalDelay := 3 * time.Minute
 
 	err := waiter.Wait(ctx,
 		&ecr.DescribeImageScanFindingsInput{
@@ -191,7 +190,7 @@ func (r *RegistryScan) WaitForScanFindings(ctx context.Context, digestInfo Image
 			},
 			MaxResults: aws.Int32(1), // reduce the size of the return payload when waiting for the completion state
 		},
-		maxTotalDelay,
+		maxWaitTime,
 		func(opts *ecr.ImageScanCompleteWaiterOptions) {
 			opts.LogWaitAttempts = true
 			opts.MinDelay = minAttemptDelay


### PR DESCRIPTION
## Purpose

Two fixes out of [CSRE-8422.](https://cultureamp.slack.com/archives/C03TM0953BM/p1786583995185719)

## Context

A perf-anytime-feedback build was timing out waiting for scan results — basic scanning on that registry takes ~4 min but the waiter gives up at 3, and there's no config to change it. Added a `max-wait-time` option (duration string, defaults to `3m` so nothing changes for existing users).

Also turns out `fail-build-on-plugin-failure` has never worked. The binary reads `FAIL_BUILD_ON_PLUGIN_FAILURE` but Buildkite exports it as `BUILDKITE_PLUGIN_ECR_SCAN_RESULTS_FAIL_BUILD_ON_PLUGIN_FAILURE`, so it was always false. Fixed the tag and added a config parsing test.
