### PR TITLE
Add fail-on-unmatched-ignores option

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,16 @@ results. This may results in builds failing even if the images have no
 vulnerabilities at all. Useful if you prefer to pass only with a confirmed good
 result.
 
+### `fail-on-unmatched-ignores` (Optional, boolean. Default: false)
+
+Ignore rules that never match a finding are reported in the annotation but
+otherwise not surfaced anywhere. Over time, these entries build up as the
+underlying vulnerabilities are fixed upstream.
+
+When set to `true`, the build will fail if any configured ignore rule did not
+match a finding in the scan, prompting you to tidy up the ignore list
+incrementally.
+
 ## Requirements
 
 ### ECR Basic scanning only

--- a/plugin.yml
+++ b/plugin.yml
@@ -19,4 +19,6 @@ configuration:
       type: string
     fail-build-on-plugin-failure:
       type: boolean
+    fail-on-unmatched-ignores:
+      type: boolean
   additionalProperties: false

--- a/src/finding/summary.go
+++ b/src/finding/summary.go
@@ -169,6 +169,30 @@ func (s Summary) FailureReasons() error {
 	return errors.Join(reasons...)
 }
 
+// UnmatchedIgnores returns the entries in the given ignore configuration that
+// were not matched against any finding in this summary. This can be used to
+// detect ignore entries that are no longer needed, e.g. because the
+// underlying vulnerability has been fixed upstream.
+func (s Summary) UnmatchedIgnores(ignoreConfig []findingconfig.Ignore) []findingconfig.Ignore {
+	matched := make(map[string]bool, len(s.Ignored))
+
+	for _, d := range s.Ignored {
+		if d.Ignore != nil {
+			matched[d.Ignore.ID] = true
+		}
+	}
+
+	unmatched := make([]findingconfig.Ignore, 0)
+
+	for _, ignore := range ignoreConfig {
+		if !matched[ignore.ID] {
+			unmatched = append(unmatched, ignore)
+		}
+	}
+
+	return unmatched
+}
+
 // includedCountFor returns the number of findings that count towards the
 // threshold for the given severity, returning 0 if there are no counts for the
 // given severity value.

--- a/src/finding/summary.go
+++ b/src/finding/summary.go
@@ -173,7 +173,16 @@ func (s Summary) FailureReasons() error {
 // were not matched against any finding in this summary. This can be used to
 // detect ignore entries that are no longer needed, e.g. because the
 // underlying vulnerability has been fixed upstream.
+//
+// If any platform's scan failed, no entries are reported as unmatched: a
+// failed platform may hold the only finding an ignore entry would have
+// matched, and we can't tell an ignore that's genuinely stale apart from one
+// that's just unscanned.
 func (s Summary) UnmatchedIgnores(ignoreConfig []findingconfig.Ignore) []findingconfig.Ignore {
+	if len(s.FailedPlatforms) > 0 {
+		return []findingconfig.Ignore{}
+	}
+
 	matched := make(map[string]bool, len(s.Ignored))
 
 	for _, d := range s.Ignored {

--- a/src/finding/summary_test.go
+++ b/src/finding/summary_test.go
@@ -251,6 +251,31 @@ func TestUnmatchedIgnoresAcrossMergedSummaries(t *testing.T) {
 	assert.Equal(t, []findingconfig.Ignore{i("CVE-2019-9999")}, unmatched)
 }
 
+func TestUnmatchedIgnoresWithPartialScanFailure(t *testing.T) {
+	ignores := []findingconfig.Ignore{
+		i("CVE-2019-5188"), // would only ever match on the platform that fails to scan
+	}
+
+	a := finding.Summarize(&ecr.DescribeImageScanFindingsOutput{
+		ImageScanStatus: &types.ImageScanStatus{
+			Status:      types.ScanStatusFailed,
+			Description: aws.String("scan failed"),
+		},
+	}, v1.Platform{OS: "a"}, ignores)
+
+	b := finding.Summarize(&ecr.DescribeImageScanFindingsOutput{
+		ImageScanFindings: &types.ImageScanFindings{
+			Findings: []types.ImageScanFinding{f("CVE-2019-5200", "CRITICAL")},
+		},
+	}, v1.Platform{OS: "b"}, ignores)
+
+	merged := finding.MergeSummaries([]finding.Summary{a, b})
+
+	unmatched := merged.UnmatchedIgnores(ignores)
+
+	assert.Equal(t, []findingconfig.Ignore{}, unmatched)
+}
+
 func p(os string) []v1.Platform {
 	return []v1.Platform{{OS: os}}
 }

--- a/src/finding/summary_test.go
+++ b/src/finding/summary_test.go
@@ -204,6 +204,53 @@ func TestMergeSummary(t *testing.T) {
 	autogold.ExpectFile(t, base)
 }
 
+func TestUnmatchedIgnores(t *testing.T) {
+	data := &ecr.DescribeImageScanFindingsOutput{
+		ImageScanFindings: &types.ImageScanFindings{
+			Findings: []types.ImageScanFinding{
+				f("CVE-2019-5188", "HIGH"),
+				f("CVE-2019-5200", "CRITICAL"),
+			},
+		},
+	}
+
+	ignores := []findingconfig.Ignore{
+		i("CVE-2019-5188"), // matches a finding
+		i("CVE-2019-9999"), // does not match any finding
+	}
+
+	summary := finding.Summarize(data, defaultPlatform, ignores)
+
+	unmatched := summary.UnmatchedIgnores(ignores)
+
+	assert.Equal(t, []findingconfig.Ignore{i("CVE-2019-9999")}, unmatched)
+}
+
+func TestUnmatchedIgnoresAcrossMergedSummaries(t *testing.T) {
+	ignores := []findingconfig.Ignore{
+		i("CVE-2019-5188"), // matched on platform "a" only
+		i("CVE-2019-9999"), // never matched
+	}
+
+	a := finding.Summarize(&ecr.DescribeImageScanFindingsOutput{
+		ImageScanFindings: &types.ImageScanFindings{
+			Findings: []types.ImageScanFinding{f("CVE-2019-5188", "HIGH")},
+		},
+	}, v1.Platform{OS: "a"}, ignores)
+
+	b := finding.Summarize(&ecr.DescribeImageScanFindingsOutput{
+		ImageScanFindings: &types.ImageScanFindings{
+			Findings: []types.ImageScanFinding{f("CVE-2019-5200", "CRITICAL")},
+		},
+	}, v1.Platform{OS: "b"}, ignores)
+
+	merged := finding.MergeSummaries([]finding.Summary{a, b})
+
+	unmatched := merged.UnmatchedIgnores(ignores)
+
+	assert.Equal(t, []findingconfig.Ignore{i("CVE-2019-9999")}, unmatched)
+}
+
 func p(os string) []v1.Platform {
 	return []v1.Platform{{OS: os}}
 }

--- a/src/main.go
+++ b/src/main.go
@@ -30,6 +30,7 @@ type Config struct {
 	CriticalSeverityThreshold int32  `envconfig:"BUILDKITE_PLUGIN_ECR_SCAN_RESULTS_MAX_CRITICALS" split_words:"true"`
 	HighSeverityThreshold     int32  `envconfig:"BUILDKITE_PLUGIN_ECR_SCAN_RESULTS_MAX_HIGHS" split_words:"true"`
 	FailBuildOnPluginFailure  bool   `envconfig:"FAIL_BUILD_ON_PLUGIN_FAILURE" default:"false"`
+	FailOnUnmatchedIgnores    bool   `envconfig:"BUILDKITE_PLUGIN_ECR_SCAN_RESULTS_FAIL_ON_UNMATCHED_IGNORES" default:"false"`
 }
 
 func main() {
@@ -173,6 +174,15 @@ func runCommand(ctx context.Context, pluginConfig Config, agent buildkite.Agent)
 
 	buildkite.Logf("Severity counts: critical=%d high=%d overThreshold=%v\n", criticalFindings, highFindings, status)
 
+	unmatchedIgnores := findingSummary.UnmatchedIgnores(ignoreConfig)
+	if len(unmatchedIgnores) > 0 {
+		buildkite.Logf("Found %d ignore rule(s) that did not match any finding:\n", len(unmatchedIgnores))
+
+		for _, ignore := range unmatchedIgnores {
+			buildkite.Logf("  - %s\n", ignore)
+		}
+	}
+
 	buildkite.Log("Creating report annotation...")
 
 	annotationCtx := report.AnnotationContext{
@@ -181,6 +191,7 @@ func runCommand(ctx context.Context, pluginConfig Config, agent buildkite.Agent)
 		FindingSummary:            findingSummary,
 		CriticalSeverityThreshold: pluginConfig.CriticalSeverityThreshold,
 		HighSeverityThreshold:     pluginConfig.HighSeverityThreshold,
+		UnmatchedIgnores:          unmatchedIgnores,
 	}
 
 	annotation, err := annotationCtx.Render()
@@ -218,14 +229,22 @@ func runCommand(ctx context.Context, pluginConfig Config, agent buildkite.Agent)
 
 	buildkite.Log("done.")
 
+	var resultErr error
+
 	switch status {
 	case finding.StatusOk:
-		return nil
+		resultErr = nil
 	case finding.StatusThresholdsExceeded:
-		return errors.New("vulnerability threshold exceeded")
+		resultErr = errors.New("vulnerability threshold exceeded")
 	default:
 		return fmt.Errorf("unknown finding summary state %d", status)
 	}
+
+	if pluginConfig.FailOnUnmatchedIgnores && len(unmatchedIgnores) > 0 {
+		resultErr = errors.Join(resultErr, fmt.Errorf("%d ignore rule(s) did not match any finding", len(unmatchedIgnores)))
+	}
+
+	return resultErr
 }
 
 // getImageScanSummary retrieves the scan results for the given image digest and

--- a/src/main.go
+++ b/src/main.go
@@ -201,12 +201,7 @@ func runCommand(ctx context.Context, pluginConfig Config, agent buildkite.Agent)
 
 	buildkite.Log("done.")
 
-	annotationStyle := "info"
-	if status != finding.StatusOk {
-		annotationStyle = "error"
-	} else if criticalFindings > 0 || highFindings > 0 {
-		annotationStyle = "warning"
-	}
+	annotationStyle := annotationStyleFor(status, criticalFindings, highFindings, pluginConfig.FailOnUnmatchedIgnores, len(unmatchedIgnores))
 
 	err = agent.Annotate(ctx, string(annotation), annotationStyle, "scan_results_"+imageDigest.Digest)
 	if err != nil {
@@ -245,6 +240,27 @@ func runCommand(ctx context.Context, pluginConfig Config, agent buildkite.Agent)
 	}
 
 	return resultErr
+}
+
+// annotationStyleFor returns the Buildkite annotation style that should be
+// used to reflect the outcome of the scan, including the case where the build
+// will be failed solely because of unmatched ignore entries.
+func annotationStyleFor(status finding.SummaryStatus, criticalFindings, highFindings int32, failOnUnmatchedIgnores bool, unmatchedIgnoresCount int) string {
+	if status != finding.StatusOk {
+		return "error"
+	}
+
+	if criticalFindings > 0 || highFindings > 0 {
+		return "warning"
+	}
+
+	if failOnUnmatchedIgnores && unmatchedIgnoresCount > 0 {
+		// this is the same condition that makes the build fail below; the
+		// annotation should reflect that visually rather than staying "info".
+		return "error"
+	}
+
+	return "info"
 }
 
 // getImageScanSummary retrieves the scan results for the given image digest and

--- a/src/main_test.go
+++ b/src/main_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/cultureamp/ecrscanresults/finding"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAnnotationStyleFor(t *testing.T) {
+	cases := []struct {
+		name                   string
+		status                 finding.SummaryStatus
+		criticalFindings       int32
+		highFindings           int32
+		failOnUnmatchedIgnores bool
+		unmatchedIgnoresCount  int
+		expected               string
+	}{
+		{
+			name:     "ok, no findings",
+			status:   finding.StatusOk,
+			expected: "info",
+		},
+		{
+			name:             "thresholds exceeded",
+			status:           finding.StatusThresholdsExceeded,
+			criticalFindings: 1,
+			expected:         "error",
+		},
+		{
+			name:         "ok but has critical/high findings under threshold",
+			status:       finding.StatusOk,
+			highFindings: 1,
+			expected:     "warning",
+		},
+		{
+			name:                   "ok, fail-on-unmatched-ignores disabled",
+			status:                 finding.StatusOk,
+			failOnUnmatchedIgnores: false,
+			unmatchedIgnoresCount:  2,
+			expected:               "info",
+		},
+		{
+			name:                   "ok, fail-on-unmatched-ignores enabled but nothing unmatched",
+			status:                 finding.StatusOk,
+			failOnUnmatchedIgnores: true,
+			unmatchedIgnoresCount:  0,
+			expected:               "info",
+		},
+		{
+			name:                   "build fails solely due to unmatched ignores",
+			status:                 finding.StatusOk,
+			failOnUnmatchedIgnores: true,
+			unmatchedIgnoresCount:  1,
+			expected:               "error",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual := annotationStyleFor(c.status, c.criticalFindings, c.highFindings, c.failOnUnmatchedIgnores, c.unmatchedIgnoresCount)
+			assert.Equal(t, c.expected, actual)
+		})
+	}
+}

--- a/src/report/annotation.go
+++ b/src/report/annotation.go
@@ -30,6 +30,7 @@ type AnnotationContext struct {
 	FindingSummary            finding.Summary
 	CriticalSeverityThreshold int32
 	HighSeverityThreshold     int32
+	UnmatchedIgnores          []findingconfig.Ignore
 }
 
 func (c AnnotationContext) Render() ([]byte, error) {

--- a/src/report/annotation.gohtml
+++ b/src/report/annotation.gohtml
@@ -51,6 +51,19 @@ be wrapped in <p> tag by the Markdown renderer in Buildkite.
 </div>
 </details>
 {{ end }}
+{{- if .UnmatchedIgnores }}
+<details class="mb3">
+<summary>:broom: {{ len .UnmatchedIgnores }} ignore rule(s) did not match any finding</summary>
+<div>
+<p class="italic">These ignore entries were not needed for this scan. Consider removing them if the underlying vulnerability has been fixed.</p>
+<ul>
+{{ range $ignore := .UnmatchedIgnores }}
+<li><em>{{ $ignore }}</em></li>
+{{ end }}
+</ul>
+</div>
+</details>
+{{ end }}
 {{ define "findingNameLink" }}{{ if .URI }}<a href="{{ .URI }}">{{ .Name }}</a>{{ else }}{{ .Name }}{{ end }}{{ end }}
 {{ define "findingName" }}{{ if .Description }}<details><summary>{{ template "findingNameLink" . }}</summary><div>{{ .Description }}</div></details>{{ else }}{{ template "findingNameLink" . }}{{ end }}{{ end }}
 {{ define "findingIgnoreUntil" }}{{ if .Until | hasUntilValue }}{{ .Until }}{{ else }}<div class="italic">(indefinitely)</div>{{ end }}{{ end }}

--- a/src/report/annotation_test.go
+++ b/src/report/annotation_test.go
@@ -286,6 +286,29 @@ func TestReports(t *testing.T) {
 				FindingSummary: fromJSON[finding.Summary](t, summaryMultiplePlatforms),
 			},
 		},
+		{
+			name: "unmatched ignores",
+			data: report.AnnotationContext{
+				Image: registry.ImageReference{
+					RegistryID: "0123456789",
+					Region:     "us-west-2",
+					Name:       "test-repo",
+					Digest:     "digest-value",
+				},
+				ImageLabel: "label of image",
+				UnmatchedIgnores: []findingconfig.Ignore{
+					{
+						ID:     "CVE-2019-0000",
+						Reason: "Fixed upstream, no longer needed",
+					},
+					{
+						ID:     "CVE-2020-0000",
+						Until:  findingconfig.MustParseUntil("2023-12-31"),
+						Reason: "Waiting on base image update",
+					},
+				},
+			},
+		},
 	}
 
 	for _, c := range cases {

--- a/src/report/testdata/TestReports/unmatched_ignores.golden
+++ b/src/report/testdata/TestReports/unmatched_ignores.golden
@@ -1,0 +1,41 @@
+`
+
+
+
+
+<h4>Vulnerability summary for "label of image"</h4>
+<p class="h6 regular italic">test-repo@digest-value</p>
+
+
+<p>✅ No vulnerabilities reported.</p>
+
+
+<details class="mb3">
+<summary>:broom: 2 ignore rule(s) did not match any finding</summary>
+<div>
+<p class="italic">These ignore entries were not needed for this scan. Consider removing them if the underlying vulnerability has been fixed.</p>
+<ul>
+
+<li><em>CVE-2019-0000 Fixed upstream, no longer needed</em></li>
+
+<li><em>CVE-2020-0000 (until 2023-12-31) Waiting on base image update</em></li>
+
+</ul>
+</div>
+</details>
+
+
+
+
+
+
+
+
+
+
+
+<p>
+<i>scan completed: <span title="&lt;nil&gt;"></span></i> |
+<i>source updated: <span title="&lt;nil&gt;"></span></i>
+</p>
+`


### PR DESCRIPTION
Closes #53.

## What this does

Following the design discussed in #53:

- Report annotation now lists any ignore entries that did not match a finding
  in the scan, so they're visible without digging through logs.
- Adds an opt-in `fail-on-unmatched-ignores` plugin option: when `true`, the
  build fails if any ignore entry went unmatched, encouraging incremental
  clean-up of the ignore list.

## Implementation notes

- `finding.Summary.UnmatchedIgnores` compares the loaded ignore config
  against the set of ignore entries actually matched by findings (post
  cross-platform merge), returning the ones that were never used.
- The existing `Summarize`/`MergeSummaries` logic already tracks which
  `Ignore` matched a given finding via `Detail.Ignore`, so no changes were
  needed there.
- Kept the default behavior unchanged: the new option defaults to `false`,
  and the annotation section only renders when there's something to show.

## Testing

- Added unit tests for `UnmatchedIgnores`, including one that merges
  per-platform summaries first (an ignore entry that matches on one platform
  but not another should still count as matched overall).
- `go build ./...`, `go vet ./...`, `go test ./...` and `gofmt -l .` all
  clean.
- Existing annotation golden-file tests pass unchanged.

## Note (not included in this diff)

While reading `main.go` I noticed `fail-build-on-plugin-failure` reads a bare
`FAIL_BUILD_ON_PLUGIN_FAILURE` env var, but Buildkite exports it prefixed as
`BUILDKITE_PLUGIN_ECR_SCAN_RESULTS_FAIL_BUILD_ON_PLUGIN_FAILURE`, so that
existing option is never actually read from pipeline config. Looks like this
is already known and fixed in #282, so I left it alone here and just used the
correct prefixed env var name for the new `fail-on-unmatched-ignores` option
so it isn't affected by the same issue.